### PR TITLE
feat: implement session connection controls

### DIFF
--- a/app/chat-client.module.css
+++ b/app/chat-client.module.css
@@ -9,9 +9,9 @@
 
 .layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 260px;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: clamp(2rem, 4vw, 3rem);
-  width: min(1100px, 100%);
+  width: min(1280px, 100%);
   min-height: clamp(28rem, 70vh, 42rem);
 }
 
@@ -64,30 +64,15 @@
 
 .controlRailInner {
   position: sticky;
-  top: clamp(2rem, 6vw, 4rem);
+  top: clamp(1.5rem, 5vw, 3rem);
   display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  width: min(100%, 16rem);
-  padding: 1.75rem;
-  border-radius: 24px;
-  border: 1px solid rgba(226, 232, 240, 1);
-  background: rgba(241, 245, 249, 0.8);
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.05);
-}
-
-.controlHeading {
-  font-size: 0.875rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-weight: 600;
-  color: rgba(71, 85, 105, 0.9);
-}
-
-.controlStack {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  width: max-content;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
 }
 
 @media (max-width: 1024px) {
@@ -101,18 +86,7 @@
 
   .controlRailInner {
     position: static;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    gap: 1.25rem;
-    width: min(100%, 28rem);
-    border-radius: 999px;
-    padding: 1rem 1.5rem;
-  }
-
-  .controlStack {
-    flex-direction: row;
-    gap: 1rem;
+    width: max-content;
   }
 }
 
@@ -126,13 +100,7 @@
   }
 
   .controlRailInner {
-    flex-direction: column;
-    border-radius: 24px;
-    width: 100%;
-  }
-
-  .controlStack {
-    flex-direction: column;
-    width: 100%;
+    width: max-content;
+    margin: 0 auto;
   }
 }

--- a/app/components/SessionControls.tsx
+++ b/app/components/SessionControls.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { MouseEvent, SyntheticEvent } from "react";
+import Alert from "@mui/material/Alert";
+import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import Snackbar from "@mui/material/Snackbar";
+import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
+import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
+import PowerOffIcon from "@mui/icons-material/PowerOff";
+
+export type ConnectionStatus = "idle" | "connecting" | "connected" | "error";
+
+export type SessionFeedback = {
+  message: string;
+  severity: "success" | "error";
+};
+
+export type SessionControlsProps = {
+  status: ConnectionStatus;
+  onConnect: () => void | Promise<void>;
+  onDisconnect: () => void | Promise<void>;
+  feedback: SessionFeedback | null;
+  onFeedbackClose: () => void;
+};
+
+export function SessionControls({
+  status,
+  onConnect,
+  onDisconnect,
+  feedback,
+  onFeedbackClose,
+}: SessionControlsProps) {
+  const isConnecting = status === "connecting";
+  const isConnected = status === "connected";
+  const isError = status === "error";
+
+  const tooltipTitle = isConnected
+    ? "Disconnect session"
+    : isConnecting
+      ? "Connecting…"
+      : isError
+        ? "Reconnect to session"
+        : "Connect to session";
+
+  const iconColor = isConnected ? "success" : isError ? "error" : "primary";
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    if (isConnecting) {
+      return;
+    }
+
+    if (isConnected) {
+      onDisconnect();
+      return;
+    }
+
+    onConnect();
+  };
+
+  const handleSnackbarClose = (_: SyntheticEvent | Event, reason?: string) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    onFeedbackClose();
+  };
+
+  return (
+    <>
+      <Stack
+        direction="column"
+        spacing={0.5}
+        alignItems="center"
+        data-testid="session-controls"
+      >
+        <Tooltip title={tooltipTitle} placement="left">
+          <span>
+            <IconButton
+              aria-label={tooltipTitle}
+              aria-pressed={isConnected}
+              color={iconColor}
+              disabled={isConnecting}
+              onClick={handleClick}
+              size="large"
+            >
+              {isConnecting ? (
+                <CircularProgress
+                  size={26}
+                  role="progressbar"
+                  aria-label="Connecting"
+                />
+              ) : isConnected ? (
+                <PowerOffIcon fontSize="inherit" />
+              ) : (
+                <PowerSettingsNewIcon fontSize="inherit" />
+              )}
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Stack>
+
+      <Snackbar
+        open={Boolean(feedback)}
+        autoHideDuration={4500}
+        onClose={handleSnackbarClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      >
+        {feedback ? (
+          <Alert
+            elevation={3}
+            severity={feedback.severity}
+            variant="filled"
+            onClose={handleSnackbarClose}
+            data-testid="session-feedback"
+          >
+            {feedback.message}
+          </Alert>
+        ) : null}
+      </Snackbar>
+    </>
+  );
+}

--- a/tests/chat/__snapshots__/chat-client.snapshot.test.tsx.snap
+++ b/tests/chat/__snapshots__/chat-client.snapshot.test.tsx.snap
@@ -36,11 +36,25 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
 }
 
 .emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-5>:not(style):not(style) {
   margin: 0;
-  font-family: Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 0.875rem;
-  line-height: 1.57;
+}
+
+.emotion-5>:not(style)~:not(style) {
+  margin-top: 4px;
 }
 
 .emotion-6 {
@@ -76,28 +90,21 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: inherit;
-  font-family: Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 0.875rem;
-  line-height: 1.75;
-  text-transform: uppercase;
-  min-width: 64px;
-  padding: 6px 16px;
-  border: 0;
-  border-radius: 4px;
-  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  color: var(--variant-containedColor);
-  background-color: var(--variant-containedBg);
-  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
-  --variant-textColor: #1976d2;
-  --variant-outlinedColor: #1976d2;
-  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
-  --variant-containedColor: #fff;
-  --variant-containedBg: #1976d2;
-  width: 100%;
-  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  text-align: center;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  font-size: 1.5rem;
+  padding: 8px;
+  border-radius: 50%;
+  color: rgba(0, 0, 0, 0.54);
+  -webkit-transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  --IconButton-hoverBg: rgba(0, 0, 0, 0.04);
+  color: #1976d2;
+  --IconButton-hoverBg: rgba(25, 118, 210, 0.04);
+  padding: 12px;
+  font-size: 1.75rem;
 }
 
 .emotion-6::-moz-focus-inner {
@@ -117,150 +124,39 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
 }
 
 .emotion-6:hover {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-6.Mui-disabled {
-  color: rgba(0, 0, 0, 0.26);
-}
-
-.emotion-6:hover {
-  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+  background-color: var(--IconButton-hoverBg);
 }
 
 @media (hover: none) {
   .emotion-6:hover {
-    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+    background-color: transparent;
   }
-}
-
-.emotion-6:active {
-  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
-}
-
-.emotion-6.Mui-focusVisible {
-  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
 .emotion-6.Mui-disabled {
+  background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
-  box-shadow: none;
-  background-color: rgba(0, 0, 0, 0.12);
 }
 
-@media (hover: hover) {
-  .emotion-6:hover {
-    --variant-containedBg: #1565c0;
-    --variant-textBg: rgba(25, 118, 210, 0.04);
-    --variant-outlinedBorder: #1976d2;
-    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
-  }
-}
-
-.emotion-6.MuiButton-loading {
+.emotion-6.MuiIconButton-loading {
   color: transparent;
 }
 
 .emotion-7 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  position: relative;
-  box-sizing: border-box;
-  -webkit-tap-highlight-color: transparent;
-  background-color: transparent;
-  outline: 0;
-  border: 0;
-  margin: 0;
-  border-radius: 0;
-  padding: 0;
-  cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  vertical-align: middle;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: inherit;
-  font-family: Roboto,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-size: 0.875rem;
-  line-height: 1.75;
-  text-transform: uppercase;
-  min-width: 64px;
-  padding: 6px 16px;
-  border: 0;
-  border-radius: 4px;
-  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  padding: 5px 15px;
-  border: 1px solid currentColor;
-  border-color: var(--variant-outlinedBorder, currentColor);
-  background-color: var(--variant-outlinedBg);
-  color: var(--variant-outlinedColor);
-  --variant-textColor: #1976d2;
-  --variant-outlinedColor: #1976d2;
-  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
-  --variant-containedColor: #fff;
-  --variant-containedBg: #1976d2;
-  width: 100%;
-  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-}
-
-.emotion-7::-moz-focus-inner {
-  border-style: none;
-}
-
-.emotion-7.Mui-disabled {
-  pointer-events: none;
-  cursor: default;
-}
-
-@media print {
-  .emotion-7 {
-    -webkit-print-color-adjust: exact;
-    color-adjust: exact;
-  }
-}
-
-.emotion-7:hover {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-7.Mui-disabled {
-  color: rgba(0, 0, 0, 0.26);
-}
-
-.emotion-7.Mui-disabled {
-  border: 1px solid rgba(0, 0, 0, 0.12);
-}
-
-@media (hover: hover) {
-  .emotion-7:hover {
-    --variant-containedBg: #1565c0;
-    --variant-textBg: rgba(25, 118, 210, 0.04);
-    --variant-outlinedBorder: #1976d2;
-    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
-  }
-}
-
-.emotion-7.MuiButton-loading {
-  color: transparent;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: inherit;
 }
 
 <section
@@ -319,29 +215,35 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
     <div
       class="controlRailInner"
     >
-      <h2
-        class="MuiTypography-root MuiTypography-subtitle2 controlHeading emotion-5"
-      >
-        Controls
-      </h2>
       <div
-        class="controlStack"
+        class="MuiStack-root emotion-5"
+        data-testid="session-controls"
       >
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth emotion-6"
-          tabindex="0"
-          type="button"
+        <span
+          aria-label="Connect to session"
+          class=""
+          data-mui-internal-clone-element="true"
         >
-          Connect
-        </button>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth emotion-7"
-          disabled=""
-          tabindex="-1"
-          type="button"
-        >
-          Disconnect
-        </button>
+          <button
+            aria-label="Connect to session"
+            aria-pressed="false"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeLarge emotion-6"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-7"
+              data-testid="PowerSettingsNewIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M13 3h-2v10h2zm4.83 2.17-1.42 1.42C17.99 7.86 19 9.81 19 12c0 3.87-3.13 7-7 7s-7-3.13-7-7c0-2.19 1.01-4.14 2.58-5.42L6.17 5.17C4.23 6.82 3 9.26 3 12c0 4.97 4.03 9 9 9s9-4.03 9-9c0-2.74-1.23-5.18-3.17-6.83"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
     </div>
   </aside>

--- a/tests/chat/session-controls.test.tsx
+++ b/tests/chat/session-controls.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import {
+  SessionControls,
+  SessionFeedback,
+  ConnectionStatus,
+} from "../../app/components/SessionControls";
+
+type RenderProps = {
+  status?: ConnectionStatus;
+  feedback?: SessionFeedback | null;
+  onConnect?: () => void;
+  onDisconnect?: () => void;
+  onFeedbackClose?: () => void;
+};
+
+function renderSessionControls({
+  status = "idle",
+  feedback = null,
+  onConnect = jest.fn(),
+  onDisconnect = jest.fn(),
+  onFeedbackClose = jest.fn(),
+}: RenderProps = {}) {
+  const theme = createTheme();
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <SessionControls
+        status={status}
+        onConnect={onConnect}
+        onDisconnect={onDisconnect}
+        feedback={feedback}
+        onFeedbackClose={onFeedbackClose}
+      />
+    </ThemeProvider>,
+  );
+
+  return {
+    ...result,
+    onConnect,
+    onDisconnect,
+    onFeedbackClose,
+  };
+}
+
+describe("SessionControls", () => {
+  it("invokes connect handler when disconnected", () => {
+    const { onConnect } = renderSessionControls();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /connect to session/i }),
+    );
+
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes disconnect handler when connected", () => {
+    const { onDisconnect } = renderSessionControls({ status: "connected" });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /disconnect session/i }),
+    );
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger handlers while connecting", () => {
+    const { onConnect, onDisconnect } = renderSessionControls({
+      status: "connecting",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /connecting/i }));
+
+    expect(onConnect).not.toHaveBeenCalled();
+    expect(onDisconnect).not.toHaveBeenCalled();
+  });
+
+  it("indicates error state via reconnect tooltip", () => {
+    renderSessionControls({ status: "error" });
+
+    expect(
+      screen.getByRole("button", { name: /reconnect to session/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders snackbar feedback and closes via the dismiss action", () => {
+    const onFeedbackClose = jest.fn();
+    renderSessionControls({
+      feedback: { message: "Connected to session", severity: "success" },
+      onFeedbackClose,
+    });
+
+    const feedback = screen.getByTestId("session-feedback");
+    expect(feedback).toHaveTextContent("Connected to session");
+
+    const closeButton = within(feedback).getByRole("button", {
+      name: /close/i,
+    });
+    fireEvent.click(closeButton);
+
+    expect(onFeedbackClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce icon-only session control rail per UI overhaul T003
- wire connection feedback with success/error snackbars
- add unit coverage for SessionControls and refresh snapshots

## Testing
- npm test

Refs #4