### PR TITLE
chore: add jest ci workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Node CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Jest suite
+        run: npm test -- --ci
+        env:
+          CI: true


### PR DESCRIPTION
## Summary
- introduce GitHub Actions workflow to run Jest on pushes and PRs targeting main
- use Node.js 20 with npm ci caching and run the project `npm test -- --ci`

## Testing
- npm test -- --ci