### PR TITLE
feat: add mic toggle session control

### DIFF
--- a/app/components/SessionControls.tsx
+++ b/app/components/SessionControls.tsx
@@ -9,6 +9,8 @@ import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
 import PowerOffIcon from "@mui/icons-material/PowerOff";
+import MicIcon from "@mui/icons-material/Mic";
+import MicOffIcon from "@mui/icons-material/MicOff";
 
 export type ConnectionStatus = "idle" | "connecting" | "connected" | "error";
 
@@ -21,6 +23,8 @@ export type SessionControlsProps = {
   status: ConnectionStatus;
   onConnect: () => void | Promise<void>;
   onDisconnect: () => void | Promise<void>;
+  muted: boolean;
+  onToggleMute: () => void;
   feedback: SessionFeedback | null;
   onFeedbackClose: () => void;
 };
@@ -29,6 +33,8 @@ export function SessionControls({
   status,
   onConnect,
   onDisconnect,
+  muted,
+  onToggleMute,
   feedback,
   onFeedbackClose,
 }: SessionControlsProps) {
@@ -44,7 +50,15 @@ export function SessionControls({
         ? "Reconnect to session"
         : "Connect to session";
 
+  const micTooltip = !isConnected
+    ? "Connect to enable microphone"
+    : muted
+      ? "Unmute microphone"
+      : "Mute microphone";
+
   const iconColor = isConnected ? "success" : isError ? "error" : "primary";
+  const micColor = muted ? "error" : "primary";
+  const micDisabled = !isConnected || isConnecting;
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -71,7 +85,7 @@ export function SessionControls({
     <>
       <Stack
         direction="column"
-        spacing={0.5}
+        spacing={1}
         alignItems="center"
         data-testid="session-controls"
       >
@@ -95,6 +109,30 @@ export function SessionControls({
                 <PowerOffIcon fontSize="inherit" />
               ) : (
                 <PowerSettingsNewIcon fontSize="inherit" />
+              )}
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title={micTooltip} placement="left">
+          <span>
+            <IconButton
+              aria-label={micTooltip}
+              aria-pressed={muted}
+              color={micColor}
+              disabled={micDisabled}
+              onClick={(event) => {
+                event.preventDefault();
+                if (micDisabled) {
+                  return;
+                }
+                onToggleMute();
+              }}
+              size="large"
+            >
+              {muted ? (
+                <MicOffIcon fontSize="inherit" />
+              ) : (
+                <MicIcon fontSize="inherit" />
               )}
             </IconButton>
           </span>

--- a/sdd/features/ui-overhaul/tasks.md
+++ b/sdd/features/ui-overhaul/tasks.md
@@ -49,7 +49,7 @@ Restructure the main page into a predominantly white canvas with a reserved cont
 ---
 
 ## Task T003: Implement Connection Toggle Control
-**Status:** Pending
+**Status:** Completed
 **Dependencies:** T002
 **Files:**
 - `app/chat-client.tsx`
@@ -71,7 +71,7 @@ Create a SessionControls component using MUI icons that toggles between connect 
 ---
 
 ## Task T004: Add Microphone Toggle Functionality
-**Status:** Pending
+**Status:** Completed
 **Dependencies:** T003
 **Files:**
 - `app/chat-client.tsx`

--- a/tests/chat/__snapshots__/chat-client.snapshot.test.tsx.snap
+++ b/tests/chat/__snapshots__/chat-client.snapshot.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
 }
 
 .emotion-5>:not(style)~:not(style) {
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 .emotion-6 {
@@ -240,6 +240,32 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
             >
               <path
                 d="M13 3h-2v10h2zm4.83 2.17-1.42 1.42C17.99 7.86 19 9.81 19 12c0 3.87-3.13 7-7 7s-7-3.13-7-7c0-2.19 1.01-4.14 2.58-5.42L6.17 5.17C4.23 6.82 3 9.26 3 12c0 4.97 4.03 9 9 9s9-4.03 9-9c0-2.74-1.23-5.18-3.17-6.83"
+              />
+            </svg>
+          </button>
+        </span>
+        <span
+          aria-label="Connect to enable microphone"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          <button
+            aria-label="Connect to enable microphone"
+            aria-pressed="false"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorPrimary MuiIconButton-sizeLarge emotion-6"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-7"
+              data-testid="MicIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 14c1.66 0 2.99-1.34 2.99-3L15 5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3m5.3-3c0 3-2.54 5.1-5.3 5.1S6.7 14 6.7 11H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c3.28-.48 6-3.3 6-6.72z"
               />
             </svg>
           </button>

--- a/tests/chat/chat-client.snapshot.test.tsx
+++ b/tests/chat/chat-client.snapshot.test.tsx
@@ -1,26 +1,29 @@
-import { render } from '@testing-library/react';
-import React from 'react';
-import Providers from '../../app/providers';
-import { ChatClient } from '../../app/chat-client';
+import { render } from "@testing-library/react";
+import React from "react";
+import Providers from "../../app/providers";
+import { ChatClient } from "../../app/chat-client";
 
-jest.mock('@openai/agents/realtime', () => {
+jest.mock("@openai/agents/realtime", () => {
   class MockRealtimeSession {
     connect = jest.fn();
     close = jest.fn();
+    mute = jest.fn();
   }
 
   return {
     RealtimeAgent: jest.fn().mockImplementation(() => ({})),
-    RealtimeSession: jest.fn().mockImplementation(() => new MockRealtimeSession()),
+    RealtimeSession: jest
+      .fn()
+      .mockImplementation(() => new MockRealtimeSession()),
   };
 });
 
-describe('ChatClient layout', () => {
-  it('matches the minimalist canvas snapshot', () => {
+describe("ChatClient layout", () => {
+  it("matches the minimalist canvas snapshot", () => {
     const { container } = render(
       <Providers>
         <ChatClient />
-      </Providers>
+      </Providers>,
     );
 
     expect(container.firstChild).toMatchSnapshot();

--- a/tests/chat/mic-toggle.test.tsx
+++ b/tests/chat/mic-toggle.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import Providers from "../../app/providers";
+import { ChatClient } from "../../app/chat-client";
+
+type MockRealtimeSession = {
+  connect: jest.Mock<Promise<void>, []>;
+  close: jest.Mock<void, []>;
+  mute: jest.Mock<void, [boolean]>;
+  muted: boolean;
+};
+
+const sessionInstances: MockRealtimeSession[] = [];
+const originalFetch = global.fetch;
+
+jest.mock("@openai/agents/realtime", () => {
+  return {
+    RealtimeAgent: jest.fn().mockImplementation(() => ({})),
+    RealtimeSession: jest.fn().mockImplementation(() => {
+      const instance = {
+        connect: jest.fn().mockResolvedValue(undefined),
+        close: jest.fn(),
+        mute: jest.fn((muted: boolean) => {
+          instance.muted = muted;
+        }),
+        muted: false,
+      } as MockRealtimeSession;
+
+      sessionInstances.push(instance);
+      return instance;
+    }),
+  };
+});
+
+const fetchMock = jest.fn();
+
+describe("ChatClient microphone toggle", () => {
+  beforeEach(() => {
+    sessionInstances.length = 0;
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: "test-token" }),
+    });
+
+    // @ts-expect-error override fetch for test environment
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("mutes and unmutes the session without reconnecting", async () => {
+    render(
+      <Providers>
+        <ChatClient />
+      </Providers>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /connect to session/i }),
+    );
+
+    await waitFor(() => expect(sessionInstances.length).toBe(1));
+    const session = sessionInstances[0];
+
+    await waitFor(() => expect(session.connect).toHaveBeenCalledTimes(1));
+
+    const muteButton = screen.getByRole("button", { name: /mute microphone/i });
+    fireEvent.click(muteButton);
+
+    expect(session.mute).toHaveBeenLastCalledWith(true);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /unmute microphone/i }),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /unmute microphone/i }));
+
+    expect(session.mute).toHaveBeenLastCalledWith(false);
+    expect(session.connect).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/chat/session-controls.test.tsx
+++ b/tests/chat/session-controls.test.tsx
@@ -11,6 +11,8 @@ type RenderProps = {
   feedback?: SessionFeedback | null;
   onConnect?: () => void;
   onDisconnect?: () => void;
+  muted?: boolean;
+  onToggleMute?: () => void;
   onFeedbackClose?: () => void;
 };
 
@@ -19,6 +21,8 @@ function renderSessionControls({
   feedback = null,
   onConnect = jest.fn(),
   onDisconnect = jest.fn(),
+  muted = false,
+  onToggleMute = jest.fn(),
   onFeedbackClose = jest.fn(),
 }: RenderProps = {}) {
   const theme = createTheme();
@@ -28,6 +32,8 @@ function renderSessionControls({
         status={status}
         onConnect={onConnect}
         onDisconnect={onDisconnect}
+        muted={muted}
+        onToggleMute={onToggleMute}
         feedback={feedback}
         onFeedbackClose={onFeedbackClose}
       />
@@ -38,6 +44,7 @@ function renderSessionControls({
     ...result,
     onConnect,
     onDisconnect,
+    onToggleMute,
     onFeedbackClose,
   };
 }
@@ -98,5 +105,31 @@ describe("SessionControls", () => {
     fireEvent.click(closeButton);
 
     expect(onFeedbackClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables microphone control until connected", () => {
+    renderSessionControls();
+
+    const button = screen.getByRole("button", {
+      name: /connect to enable microphone/i,
+    });
+
+    expect(button).toBeDisabled();
+  });
+
+  it("invokes mute toggle when connected", () => {
+    const { onToggleMute } = renderSessionControls({ status: "connected" });
+
+    fireEvent.click(screen.getByRole("button", { name: /mute microphone/i }));
+
+    expect(onToggleMute).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows unmute label when muted", () => {
+    renderSessionControls({ status: "connected", muted: true });
+
+    expect(
+      screen.getByRole("button", { name: /unmute microphone/i }),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add microphone toggle to session controls with stateful feedback
- wire ChatClient to call realtime session mute without reconnecting
- cover icon control states and add mic toggle integration test

## Testing
- npm test

Refs #5