### PR TITLE
Add voice activity meter to chat client

### DIFF
--- a/app/chat-client.module.css
+++ b/app/chat-client.module.css
@@ -19,7 +19,7 @@
   display: flex;
   flex-direction: column;
   gap: clamp(1.5rem, 2vw, 2.5rem);
-  padding: clamp(2.5rem, 5vw, 3.5rem);
+  padding: clamp(2.5rem, 5vw, 3.75rem);
   border-radius: 24px;
   border: 1px solid rgba(15, 23, 42, 0.08);
   background-color: #ffffff;
@@ -54,6 +54,20 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.statusText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 28rem;
+}
+
+.voiceMeterWrapper {
+  display: flex;
+  justify-content: flex-end;
+  align-self: flex-end;
+  margin-top: 0.75rem;
 }
 
 .controlRail {
@@ -102,5 +116,10 @@
   .controlRailInner {
     width: max-content;
     margin: 0 auto;
+  }
+
+  .voiceMeterWrapper {
+    width: 100%;
+    justify-content: center;
   }
 }

--- a/app/chat-client.tsx
+++ b/app/chat-client.tsx
@@ -10,6 +10,82 @@ import {
   SessionFeedback,
   ConnectionStatus,
 } from "./components/SessionControls";
+import { VoiceMeter } from "./components/VoiceMeter";
+
+type VoiceMeterState = {
+  level: number;
+  active: boolean;
+  hasMetrics: boolean;
+};
+
+type VoiceActivitySession = RealtimeSession & {
+  on?: (event: string, listener: (payload: unknown) => void) => void;
+  off?: (event: string, listener: (payload: unknown) => void) => void;
+  removeListener?: (event: string, listener: (payload: unknown) => void) => void;
+  addEventListener?: (event: string, listener: (payload: unknown) => void) => void;
+  removeEventListener?: (event: string, listener: (payload: unknown) => void) => void;
+  getLatestAudioLevel?: () => number | null | undefined;
+};
+
+const defaultVoiceMeterState: VoiceMeterState = {
+  level: 0,
+  active: false,
+  hasMetrics: false,
+};
+
+type NormalizedVoicePayload = {
+  level?: number;
+  active?: boolean;
+};
+
+const voiceActivityEventCandidates = [
+  "voice-activity",
+  "audio-activity",
+  "audio.activity",
+];
+
+const clampLevel = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+};
+
+const normalizeVoicePayload = (payload: unknown): NormalizedVoicePayload => {
+  if (typeof payload === "number") {
+    return { level: clampLevel(payload) };
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return {};
+  }
+
+  const data = payload as Record<string, unknown>;
+  const levelCandidate = [
+    data.level,
+    data.volume,
+    data.value,
+    data.amplitude,
+  ].find((candidate) => typeof candidate === "number" && Number.isFinite(candidate));
+
+  const state =
+    typeof data.state === "string" ? data.state.toLowerCase() : undefined;
+
+  let active: boolean | undefined;
+  if (typeof data.active === "boolean") {
+    active = data.active;
+  } else if (typeof data.speaking === "boolean") {
+    active = data.speaking;
+  } else if (state) {
+    active = state !== "idle" && state !== "inactive";
+  }
+
+  return {
+    level:
+      typeof levelCandidate === "number" ? clampLevel(levelCandidate) : undefined,
+    active,
+  };
+};
 
 export function ChatClient() {
   const [status, setStatus] = useState<ConnectionStatus>("idle");
@@ -17,6 +93,9 @@ export function ChatClient() {
   const [feedback, setFeedback] = useState<SessionFeedback | null>(null);
   const [muted, setMuted] = useState(false);
   const [session, setSession] = useState<RealtimeSession | null>(null);
+  const [voiceMeter, setVoiceMeter] = useState<VoiceMeterState>(
+    defaultVoiceMeterState,
+  );
 
   useEffect(() => {
     return () => {
@@ -75,12 +154,14 @@ export function ChatClient() {
       setStatus("connected");
       setFeedback({ message: "Connected to session", severity: "success" });
       setMuted(Boolean(newSession.muted));
+      setVoiceMeter(defaultVoiceMeterState);
     } catch (err) {
       console.error("Failed to connect realtime session", err);
       setStatus("error");
       const message = err instanceof Error ? err.message : "Unexpected error";
       setError(message);
       setFeedback({ message, severity: "error" });
+      setVoiceMeter(defaultVoiceMeterState);
     }
   }, [agent, session, status]);
 
@@ -91,6 +172,7 @@ export function ChatClient() {
     setError(null);
     setMuted(false);
     setFeedback({ message: "Disconnected from session", severity: "success" });
+    setVoiceMeter(defaultVoiceMeterState);
   }, [session]);
 
   const handleToggleMute = useCallback(() => {
@@ -122,6 +204,127 @@ export function ChatClient() {
     setFeedback(null);
   }, []);
 
+  useEffect(() => {
+    if (!session || status !== "connected") {
+      setVoiceMeter(defaultVoiceMeterState);
+      return;
+    }
+
+    setVoiceMeter(defaultVoiceMeterState);
+
+    let disposed = false;
+    const voiceSession = session as VoiceActivitySession;
+    const cleanups: Array<() => void> = [];
+
+    const handlePayload = (payload: unknown) => {
+      if (disposed) {
+        return;
+      }
+
+      const normalized = normalizeVoicePayload(payload);
+      const hasLevel = typeof normalized.level === "number";
+
+      setVoiceMeter((previous) => {
+        const nextLevel = hasLevel
+          ? normalized.level ?? 0
+          : normalized.active === true
+            ? Math.max(previous.level, 0.65)
+            : normalized.active === false
+              ? 0
+              : previous.level;
+
+        const nextActive =
+          typeof normalized.active === "boolean"
+            ? normalized.active
+            : hasLevel
+              ? (normalized.level ?? 0) > 0.12
+              : previous.active;
+
+        const nextHasMetrics = hasLevel
+          ? true
+          : typeof normalized.active === "boolean"
+            ? true
+            : previous.hasMetrics;
+
+        if (
+          nextLevel === previous.level &&
+          nextActive === previous.active &&
+          nextHasMetrics === previous.hasMetrics
+        ) {
+          return previous;
+        }
+
+        return {
+          level: nextLevel,
+          active: nextActive,
+          hasMetrics: nextHasMetrics,
+        };
+      });
+    };
+
+    const attachListener = (eventName: string) => {
+      let attached = false;
+
+      if (typeof voiceSession.on === "function") {
+        const listener = (payload: unknown) => {
+          handlePayload(payload);
+        };
+        voiceSession.on(eventName, listener);
+        cleanups.push(() => {
+          if (typeof voiceSession.off === "function") {
+            voiceSession.off(eventName, listener);
+          } else if (typeof voiceSession.removeListener === "function") {
+            voiceSession.removeListener(eventName, listener);
+          }
+        });
+        attached = true;
+      } else if (typeof voiceSession.addEventListener === "function") {
+        const listener = (payload: unknown) => {
+          handlePayload(payload);
+        };
+        voiceSession.addEventListener(eventName, listener);
+        cleanups.push(() => {
+          if (typeof voiceSession.removeEventListener === "function") {
+            voiceSession.removeEventListener(eventName, listener);
+          }
+        });
+        attached = true;
+      }
+
+      return attached;
+    };
+
+    const attachedEvents = voiceActivityEventCandidates.map((eventName) =>
+      attachListener(eventName),
+    );
+    const hasListener = attachedEvents.some(Boolean);
+
+    if (!hasListener && typeof window !== "undefined") {
+      const poller =
+        typeof voiceSession.getLatestAudioLevel === "function"
+          ? window.setInterval(() => {
+              const value = voiceSession.getLatestAudioLevel?.();
+              if (typeof value === "number" && Number.isFinite(value)) {
+                handlePayload({ level: value });
+              }
+            }, 250)
+          : null;
+
+      if (poller) {
+        cleanups.push(() => {
+          window.clearInterval(poller);
+        });
+      }
+    }
+
+    return () => {
+      disposed = true;
+      cleanups.forEach((cleanup) => {
+        cleanup();
+      });
+    };
+  }, [session, status]);
+
   return (
     <section className={styles.layout} aria-labelledby="chat-title">
       <div className={styles.canvas}>
@@ -148,16 +351,25 @@ export function ChatClient() {
         </div>
 
         <footer className={styles.status} aria-live="polite">
-          <Typography variant="body2">Status: {status}</Typography>
-          {error ? (
-            <Typography variant="body2" color="error">
-              Error: {error}
-            </Typography>
-          ) : (
-            <Typography variant="body2" color="text.secondary">
-              Allow microphone access when prompted to keep the session ready.
-            </Typography>
-          )}
+          <div className={styles.statusText}>
+            <Typography variant="body2">Status: {status}</Typography>
+            {error ? (
+              <Typography variant="body2" color="error">
+                Error: {error}
+              </Typography>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                Allow microphone access when prompted to keep the session ready.
+              </Typography>
+            )}
+          </div>
+          <div className={styles.voiceMeterWrapper}>
+            <VoiceMeter
+              active={voiceMeter.active}
+              level={voiceMeter.level}
+              hasMetrics={voiceMeter.hasMetrics}
+            />
+          </div>
         </footer>
       </div>
 

--- a/app/components/VoiceMeter.tsx
+++ b/app/components/VoiceMeter.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import { alpha } from "@mui/material/styles";
+
+export type VoiceMeterProps = {
+  active: boolean;
+  level: number;
+  hasMetrics: boolean;
+};
+
+const BAR_COUNT = 4;
+
+export function VoiceMeter({ active, level, hasMetrics }: VoiceMeterProps) {
+  const clampedLevel = Math.max(0, Math.min(1, Number.isFinite(level) ? level : 0));
+
+  return (
+    <Paper
+      elevation={6}
+      sx={{
+        px: 2,
+        py: 1.5,
+        borderRadius: 3,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+        minWidth: 168,
+        pointerEvents: "auto",
+      }}
+      role="status"
+      aria-label="Voice activity"
+      aria-live="polite"
+      data-testid="voice-meter"
+    >
+      <Typography variant="caption" color="text.secondary">
+        Voice activity
+      </Typography>
+
+      {hasMetrics ? (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "flex-end",
+            justifyContent: "space-between",
+            gap: 0.5,
+            height: 36,
+          }}
+          aria-hidden
+        >
+          {Array.from({ length: BAR_COUNT }).map((_, index) => {
+            const step = (index + 1) / BAR_COUNT;
+            const barActive = clampedLevel >= step;
+            return (
+              <Box
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                sx={{
+                  flex: 1,
+                  height: 18 + index * 6,
+                  borderRadius: 1,
+                  transition: "background-color 160ms ease, transform 160ms ease",
+                  transform: barActive
+                    ? `scaleY(${1 + clampedLevel * 0.15})`
+                    : "scaleY(1)",
+                  transformOrigin: "center bottom",
+                  backgroundColor: (theme) =>
+                    barActive
+                      ? theme.palette.success.main
+                      : alpha(theme.palette.success.light, 0.25),
+                }}
+              />
+            );
+          })}
+        </Box>
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          Waiting for audio…
+        </Typography>
+      )}
+
+      <Box display="flex" alignItems="center" justifyContent="space-between">
+        <Box
+          sx={{
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            transition: "all 160ms ease",
+            backgroundColor: (theme) =>
+              active ? theme.palette.success.main : theme.palette.grey[400],
+            boxShadow: (theme) =>
+              active ? `0 0 0 4px ${alpha(theme.palette.success.light, 0.35)}` : "none",
+          }}
+        />
+        <Typography
+          variant="caption"
+          color={active ? "success.main" : hasMetrics ? "text.secondary" : "text.disabled"}
+          sx={{ fontWeight: 600 }}
+        >
+          {active ? "Speaking" : hasMetrics ? "Idle" : "Inactive"}
+        </Typography>
+      </Box>
+    </Paper>
+  );
+}

--- a/tests/chat/__snapshots__/chat-client.snapshot.test.tsx.snap
+++ b/tests/chat/__snapshots__/chat-client.snapshot.test.tsx.snap
@@ -36,6 +36,74 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
 }
 
 .emotion-5 {
+  background-color: #ffffff;
+  color: rgba(0, 0, 0, 0.87);
+  -webkit-transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  border-radius: 4px;
+  box-shadow: var(--Paper-shadow);
+  background-image: var(--Paper-overlay);
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  border-radius: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 168px;
+  pointer-events: auto;
+}
+
+.emotion-6 {
+  margin: 0;
+  font-family: Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.66;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.emotion-9 {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  -webkit-transition: all 160ms ease;
+  transition: all 160ms ease;
+  background-color: #bdbdbd;
+  box-shadow: none;
+}
+
+.emotion-10 {
+  margin: 0;
+  font-family: Roboto,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.66;
+  color: rgba(0, 0, 0, 0.38);
+  font-weight: 600;
+}
+
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,15 +117,15 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
   align-items: center;
 }
 
-.emotion-5>:not(style):not(style) {
+.emotion-11>:not(style):not(style) {
   margin: 0;
 }
 
-.emotion-5>:not(style)~:not(style) {
+.emotion-11>:not(style)~:not(style) {
   margin-top: 8px;
 }
 
-.emotion-6 {
+.emotion-12 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -107,42 +175,42 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
   font-size: 1.75rem;
 }
 
-.emotion-6::-moz-focus-inner {
+.emotion-12::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-6.Mui-disabled {
+.emotion-12.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-6 {
+  .emotion-12 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-6:hover {
+.emotion-12:hover {
   background-color: var(--IconButton-hoverBg);
 }
 
 @media (hover: none) {
-  .emotion-6:hover {
+  .emotion-12:hover {
     background-color: transparent;
   }
 }
 
-.emotion-6.Mui-disabled {
+.emotion-12.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-6.MuiIconButton-loading {
+.emotion-12.MuiIconButton-loading {
   color: transparent;
 }
 
-.emotion-7 {
+.emotion-13 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -195,17 +263,56 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
       aria-live="polite"
       class="status"
     >
-      <p
-        class="MuiTypography-root MuiTypography-body2 emotion-3"
+      <div
+        class="statusText"
       >
-        Status: 
-        idle
-      </p>
-      <p
-        class="MuiTypography-root MuiTypography-body2 emotion-2"
+        <p
+          class="MuiTypography-root MuiTypography-body2 emotion-3"
+        >
+          Status: 
+          idle
+        </p>
+        <p
+          class="MuiTypography-root MuiTypography-body2 emotion-2"
+        >
+          Allow microphone access when prompted to keep the session ready.
+        </p>
+      </div>
+      <div
+        class="voiceMeterWrapper"
       >
-        Allow microphone access when prompted to keep the session ready.
-      </p>
+        <div
+          aria-label="Voice activity"
+          aria-live="polite"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation6 emotion-5"
+          data-testid="voice-meter"
+          role="status"
+          style="--Paper-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-caption emotion-6"
+          >
+            Voice activity
+          </span>
+          <p
+            class="MuiTypography-root MuiTypography-body2 emotion-2"
+          >
+            Waiting for audio…
+          </p>
+          <div
+            class="MuiBox-root emotion-8"
+          >
+            <div
+              class="MuiBox-root emotion-9"
+            />
+            <span
+              class="MuiTypography-root MuiTypography-caption emotion-10"
+            >
+              Inactive
+            </span>
+          </div>
+        </div>
+      </div>
     </footer>
   </div>
   <aside
@@ -216,7 +323,7 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
       class="controlRailInner"
     >
       <div
-        class="MuiStack-root emotion-5"
+        class="MuiStack-root emotion-11"
         data-testid="session-controls"
       >
         <span
@@ -227,13 +334,13 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
           <button
             aria-label="Connect to session"
             aria-pressed="false"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeLarge emotion-6"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeLarge emotion-12"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-7"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
               data-testid="PowerSettingsNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -252,14 +359,14 @@ exports[`ChatClient layout matches the minimalist canvas snapshot 1`] = `
           <button
             aria-label="Connect to enable microphone"
             aria-pressed="false"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorPrimary MuiIconButton-sizeLarge emotion-6"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorPrimary MuiIconButton-sizeLarge emotion-12"
             disabled=""
             tabindex="-1"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-7"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
               data-testid="MicIcon"
               focusable="false"
               viewBox="0 0 24 24"

--- a/tests/chat/voice-meter.test.tsx
+++ b/tests/chat/voice-meter.test.tsx
@@ -1,0 +1,90 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { EventEmitter } from "events";
+import Providers from "../../app/providers";
+import { ChatClient } from "../../app/chat-client";
+
+type MockRealtimeSession = EventEmitter & {
+  connect: jest.Mock<Promise<void>, []>;
+  close: jest.Mock<void, []>;
+  mute: jest.Mock<void, [boolean]>;
+  muted: boolean;
+};
+
+const sessionInstances: MockRealtimeSession[] = [];
+const originalFetch = global.fetch;
+
+jest.mock("@openai/agents/realtime", () => {
+  class MockSession extends EventEmitter {
+    connect = jest.fn().mockResolvedValue(undefined);
+
+    close = jest.fn();
+
+    mute = jest.fn((nextMuted: boolean) => {
+      this.muted = nextMuted;
+    });
+
+    muted = false;
+  }
+
+  return {
+    RealtimeAgent: jest.fn().mockImplementation(() => ({})),
+    RealtimeSession: jest.fn().mockImplementation(() => {
+      const instance = new MockSession() as MockRealtimeSession;
+      sessionInstances.push(instance);
+      return instance;
+    }),
+  };
+});
+
+const fetchMock = jest.fn();
+
+describe("ChatClient voice meter", () => {
+  beforeEach(() => {
+    sessionInstances.length = 0;
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: "test-token" }),
+    });
+
+    // @ts-expect-error override fetch for test environment
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("maps session voice activity events to the UI", async () => {
+    render(
+      <Providers>
+        <ChatClient />
+      </Providers>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /connect to session/i }));
+
+    await waitFor(() => expect(sessionInstances.length).toBe(1));
+    const session = sessionInstances[0];
+
+    await waitFor(() => expect(session.connect).toHaveBeenCalledTimes(1));
+
+    const voiceMeter = await screen.findByTestId("voice-meter");
+    expect(voiceMeter).toHaveTextContent(/waiting for audio/i);
+    expect(voiceMeter).toHaveTextContent(/inactive/i);
+
+    await act(async () => {
+      session.emit("voice-activity", { level: 0.8 });
+    });
+
+    await waitFor(() => expect(voiceMeter).toHaveTextContent(/speaking/i));
+    expect(voiceMeter).not.toHaveTextContent(/waiting for audio/i);
+
+    await act(async () => {
+      session.emit("voice-activity", { active: false });
+    });
+
+    await waitFor(() => expect(voiceMeter).toHaveTextContent(/idle/i));
+  });
+});


### PR DESCRIPTION
## Summary
- add a Material UI voice activity meter component to visualize session playback
- wire the chat client to realtime voice activity events and expose the meter in the canvas footer
- expand the Jest suite with a voice meter test and refresh the chat client snapshot

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4057d5960832e967a620d2c4b7355