### PR TITLE
feat: capture realtime transcript state

### DIFF
--- a/app/chat-client.tsx
+++ b/app/chat-client.tsx
@@ -10,6 +10,7 @@ import {
   SessionFeedback,
   ConnectionStatus,
 } from "./components/SessionControls";
+import { TranscriptStore } from "./lib/transcript-store";
 
 export function ChatClient() {
   const [status, setStatus] = useState<ConnectionStatus>("idle");
@@ -17,12 +18,27 @@ export function ChatClient() {
   const [feedback, setFeedback] = useState<SessionFeedback | null>(null);
   const [muted, setMuted] = useState(false);
   const [session, setSession] = useState<RealtimeSession | null>(null);
+  const transcriptStore = useMemo(() => new TranscriptStore(), []);
 
   useEffect(() => {
     return () => {
       session?.close();
     };
   }, [session]);
+
+  useEffect(() => {
+    transcriptStore.setSession(session);
+
+    return () => {
+      transcriptStore.setSession(null);
+    };
+  }, [session, transcriptStore]);
+
+  useEffect(() => {
+    return () => {
+      transcriptStore.dispose();
+    };
+  }, [transcriptStore]);
 
   const agent = useMemo(() => {
     return new RealtimeAgent({

--- a/app/lib/transcript-store.ts
+++ b/app/lib/transcript-store.ts
@@ -1,0 +1,167 @@
+import type { RealtimeItem, RealtimeSession } from "@openai/agents/realtime";
+
+type TranscriptRole = "user" | "assistant";
+
+export type TranscriptEntry = {
+  id: string;
+  role: TranscriptRole;
+  text: string;
+};
+
+type TranscriptListener = (entries: TranscriptEntry[]) => void;
+
+function isMessageItem(
+  item: RealtimeItem,
+): item is Extract<RealtimeItem, { type: "message" }> {
+  return item.type === "message";
+}
+
+function isConversationRole(
+  item: Extract<RealtimeItem, { type: "message" }>,
+): item is Extract<RealtimeItem, { type: "message"; role: TranscriptRole }> {
+  return item.role === "user" || item.role === "assistant";
+}
+
+function isFinalStatus(status: string | undefined): boolean {
+  return status === "completed" || status === "incomplete";
+}
+
+function extractTextFromContent(
+  item: Extract<RealtimeItem, { type: "message"; role: TranscriptRole }>,
+): string {
+  return item.content
+    .map((part) => {
+      if (part.type === "input_text" || part.type === "output_text") {
+        return part.text;
+      }
+
+      if (part.type === "input_audio" || part.type === "output_audio") {
+        return part.transcript ?? "";
+      }
+
+      return "";
+    })
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+}
+
+function buildTranscriptEntries(history: RealtimeItem[]): TranscriptEntry[] {
+  return history
+    .filter(isMessageItem)
+    .filter(isConversationRole)
+    .filter((item) =>
+      "status" in item ? isFinalStatus(item.status) : true,
+    )
+    .map((item) => ({
+      id: item.itemId,
+      role: item.role,
+      text: extractTextFromContent(item),
+    }))
+    .filter((entry) => entry.text.length > 0);
+}
+
+export class TranscriptStore {
+  private entries: TranscriptEntry[] = [];
+
+  private listeners = new Set<TranscriptListener>();
+
+  private session: RealtimeSession | null = null;
+
+  private unbindSession: (() => void) | null = null;
+
+  getEntries(): TranscriptEntry[] {
+    return this.entries;
+  }
+
+  subscribe(listener: TranscriptListener): () => void {
+    this.listeners.add(listener);
+    listener(this.entries);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  setSession(session: RealtimeSession | null): void {
+    if (this.session === session) {
+      return;
+    }
+
+    this.teardownSessionBinding();
+
+    this.session = session;
+
+    if (!session) {
+      this.reset();
+      return;
+    }
+
+    const updateFromHistory = () => {
+      this.entries = buildTranscriptEntries(session.history);
+      this.emit();
+    };
+
+    session.on("history_updated", updateFromHistory);
+    session.on("history_added", updateFromHistory);
+
+    this.unbindSession = () => {
+      session.off("history_updated", updateFromHistory);
+      session.off("history_added", updateFromHistory);
+    };
+
+    updateFromHistory();
+  }
+
+  reset(): void {
+    if (this.entries.length === 0) {
+      return;
+    }
+
+    this.entries = [];
+    this.emit();
+  }
+
+  sendTextMessage(text: string): void {
+    const session = this.session;
+
+    if (!session) {
+      throw new Error("Cannot send message without an active session");
+    }
+
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    session.sendMessage({
+      type: "message",
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: trimmed,
+        },
+      ],
+    });
+  }
+
+  dispose(): void {
+    this.teardownSessionBinding();
+    this.listeners.clear();
+    this.entries = [];
+    this.session = null;
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) {
+      listener(this.entries);
+    }
+  }
+
+  private teardownSessionBinding(): void {
+    if (this.unbindSession) {
+      this.unbindSession();
+      this.unbindSession = null;
+    }
+  }
+}

--- a/tests/chat/chat-client.snapshot.test.tsx
+++ b/tests/chat/chat-client.snapshot.test.tsx
@@ -8,6 +8,9 @@ jest.mock("@openai/agents/realtime", () => {
     connect = jest.fn();
     close = jest.fn();
     mute = jest.fn();
+    history: unknown[] = [];
+    on = jest.fn();
+    off = jest.fn();
   }
 
   return {

--- a/tests/chat/mic-toggle.test.tsx
+++ b/tests/chat/mic-toggle.test.tsx
@@ -7,6 +7,9 @@ type MockRealtimeSession = {
   close: jest.Mock<void, []>;
   mute: jest.Mock<void, [boolean]>;
   muted: boolean;
+  history: unknown[];
+  on: jest.Mock;
+  off: jest.Mock;
 };
 
 const sessionInstances: MockRealtimeSession[] = [];
@@ -23,6 +26,9 @@ jest.mock("@openai/agents/realtime", () => {
           instance.muted = muted;
         }),
         muted: false,
+        history: [],
+        on: jest.fn(),
+        off: jest.fn(),
       } as MockRealtimeSession;
 
       sessionInstances.push(instance);

--- a/tests/chat/transcript-store.test.ts
+++ b/tests/chat/transcript-store.test.ts
@@ -1,0 +1,141 @@
+import { EventEmitter } from "node:events";
+import type { RealtimeItem, RealtimeSession } from "@openai/agents/realtime";
+import { TranscriptStore } from "../../app/lib/transcript-store";
+
+type MessageItem = Extract<RealtimeItem, { type: "message" }>;
+
+class MockRealtimeSession
+  extends EventEmitter
+  implements Pick<RealtimeSession, "history" | "sendMessage">
+{
+  history: RealtimeItem[] = [];
+
+  sendMessage = jest.fn();
+
+  setHistory(items: RealtimeItem[]): void {
+    this.history = items;
+    this.emit("history_updated", items);
+  }
+
+  addMessage(item: RealtimeItem): void {
+    this.history = [...this.history, item];
+    this.emit("history_added", item);
+  }
+}
+
+function createUserMessage(
+  id: string,
+  text: string,
+  overrides: Partial<MessageItem> = {},
+): MessageItem {
+  return {
+    itemId: id,
+    type: "message",
+    role: "user",
+    status: "completed",
+    content: [
+      {
+        type: "input_text",
+        text,
+      },
+    ],
+    ...overrides,
+  } as MessageItem;
+}
+
+function createAssistantMessage(
+  id: string,
+  text: string,
+  overrides: Partial<MessageItem> = {},
+): MessageItem {
+  return {
+    itemId: id,
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [
+      {
+        type: "output_text",
+        text,
+      },
+    ],
+    ...overrides,
+  } as MessageItem;
+}
+
+describe("TranscriptStore", () => {
+  it("records entries in chronological order", () => {
+    const session = new MockRealtimeSession();
+    const store = new TranscriptStore();
+
+    store.setSession(session as unknown as RealtimeSession);
+
+    session.setHistory([
+      createUserMessage("1", "Hello"),
+      createAssistantMessage("2", "Hi there"),
+    ]);
+
+    expect(store.getEntries()).toEqual([
+      { id: "1", role: "user", text: "Hello" },
+      { id: "2", role: "assistant", text: "Hi there" },
+    ]);
+  });
+
+  it("sends text messages through the session and waits for confirmation", () => {
+    const session = new MockRealtimeSession();
+    const store = new TranscriptStore();
+
+    store.setSession(session as unknown as RealtimeSession);
+
+    store.sendTextMessage("  Hello world  ");
+
+    expect(session.sendMessage).toHaveBeenCalledWith({
+      type: "message",
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: "Hello world",
+        },
+      ],
+    });
+    expect(store.getEntries()).toEqual([]);
+
+    session.addMessage(createUserMessage("1", "Hello world"));
+
+    expect(store.getEntries()).toEqual([
+      { id: "1", role: "user", text: "Hello world" },
+    ]);
+  });
+
+  it("ignores empty submissions and resets when session detaches", () => {
+    const session = new MockRealtimeSession();
+    const store = new TranscriptStore();
+
+    store.setSession(session as unknown as RealtimeSession);
+
+    store.sendTextMessage("   ");
+
+    expect(session.sendMessage).not.toHaveBeenCalled();
+
+    session.setHistory([createAssistantMessage("1", "Welcome!")]);
+
+    expect(store.getEntries()).toHaveLength(1);
+
+    store.setSession(null);
+
+    expect(store.getEntries()).toEqual([]);
+
+    session.addMessage(createUserMessage("2", "Should be ignored"));
+
+    expect(store.getEntries()).toEqual([]);
+  });
+
+  it("throws when sending without an active session", () => {
+    const store = new TranscriptStore();
+
+    expect(() => store.sendTextMessage("Hello")).toThrow(
+      /active session/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a TranscriptStore for deriving ordered transcript entries from realtime session history
- wire ChatClient to attach and dispose the transcript store alongside session lifecycle
- add unit coverage for the store and update realtime session mocks to satisfy new listeners

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e405914f6c832ea38dad1f98a6fd09