### PR TITLE
feat/26 ui rail refine

### DIFF
--- a/app/components/SessionControls.tsx
+++ b/app/components/SessionControls.tsx
@@ -5,17 +5,15 @@ import Alert from "@mui/material/Alert";
 import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
 import Snackbar from "@mui/material/Snackbar";
-import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
-import Box from "@mui/material/Box";
-import { visuallyHidden } from "@mui/utils";
 import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
 import PowerOffIcon from "@mui/icons-material/PowerOff";
 import MicIcon from "@mui/icons-material/Mic";
 import MicOffIcon from "@mui/icons-material/MicOff";
-import FiberManualRecordIcon from "@mui/icons-material/FiberManualRecord";
-import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import SubjectIcon from "@mui/icons-material/Subject";
+import DarkModeIcon from "@mui/icons-material/DarkMode";
+import LightModeIcon from "@mui/icons-material/LightMode";
+import styles from "./controls.module.css";
 
 export type ConnectionStatus = "idle" | "connecting" | "connected" | "error";
 
@@ -36,6 +34,8 @@ export type SessionControlsProps = {
   voiceHasMetrics: boolean;
   transcriptOpen: boolean;
   onToggleTranscript: () => void;
+  themeMode?: "light" | "dark";
+  onToggleTheme?: (() => void) | null;
 };
 
 type VoiceActivityIndicatorProps = {
@@ -50,37 +50,21 @@ function VoiceActivityIndicator({ active, hasMetrics }: VoiceActivityIndicatorPr
       ? "AI is idle"
       : "Waiting for audio";
 
-  const Icon = active ? GraphicEqIcon : FiberManualRecordIcon;
-  const color = active ? "success.main" : hasMetrics ? "text.secondary" : "text.disabled";
-
   return (
-    <Box
+    <div
+      className={styles.voiceIndicator}
+      data-active={active ? "true" : "false"}
+      data-ready={hasMetrics ? "true" : "false"}
       role="status"
       aria-live="polite"
       aria-label={label}
       data-testid="voice-activity-indicator"
-      sx={{
-        mt: 2,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        borderRadius: 999,
-        backgroundColor: (theme) => theme.palette.action.hover,
-        padding: "0.35rem 0.5rem",
-      }}
     >
-      <Icon
-        fontSize="small"
-        sx={{
-          color,
-          transition: "transform 180ms ease, color 180ms ease",
-          transform: active ? "scale(1.1)" : "scale(0.9)",
-        }}
-      />
-      <Box component="span" sx={visuallyHidden}>
+      <span className={styles.voiceIndicatorCore} aria-hidden="true" />
+      <span className={styles.srOnly}>
         {label}
-      </Box>
-    </Box>
+      </span>
+    </div>
   );
 }
 
@@ -96,6 +80,8 @@ export function SessionControls({
   voiceHasMetrics,
   transcriptOpen,
   onToggleTranscript,
+  themeMode = "light",
+  onToggleTheme,
 }: SessionControlsProps) {
   const isConnecting = status === "connecting";
   const isConnected = status === "connected";
@@ -118,6 +104,10 @@ export function SessionControls({
   const transcriptTooltip = transcriptOpen
     ? "Close transcript drawer"
     : "Open transcript drawer";
+  const resolvedThemeMode = themeMode === "dark" ? "dark" : "light";
+  const themeTooltip =
+    resolvedThemeMode === "dark" ? "Switch to light mode" : "Switch to dark mode";
+  const themeDisabled = typeof onToggleTheme !== "function";
 
   const iconColor = isConnected ? "success" : isError ? "error" : "primary";
   const micColor = muted ? "error" : "primary";
@@ -146,14 +136,9 @@ export function SessionControls({
 
   return (
     <>
-      <Stack
-        direction="column"
-        spacing={1}
-        alignItems="center"
-        data-testid="session-controls"
-      >
+      <div className={styles.rail} data-testid="session-controls" data-align="edge">
         <Tooltip title={tooltipTitle} placement="left">
-          <span>
+          <span className={styles.iconWrapper}>
             <IconButton
               aria-label={tooltipTitle}
               aria-pressed={isConnected}
@@ -161,6 +146,7 @@ export function SessionControls({
               disabled={isConnecting}
               onClick={handleClick}
               size="large"
+              className={styles.iconButton}
             >
               {isConnecting ? (
                 <CircularProgress
@@ -177,7 +163,7 @@ export function SessionControls({
           </span>
         </Tooltip>
         <Tooltip title={micTooltip} placement="left">
-          <span>
+          <span className={styles.iconWrapper}>
             <IconButton
               aria-label={micTooltip}
               aria-pressed={muted}
@@ -191,6 +177,7 @@ export function SessionControls({
                 onToggleMute();
               }}
               size="large"
+              className={styles.iconButton}
             >
               {muted ? (
                 <MicOffIcon fontSize="inherit" />
@@ -201,7 +188,7 @@ export function SessionControls({
           </span>
         </Tooltip>
         <Tooltip title={transcriptTooltip} placement="left">
-          <span>
+          <span className={styles.iconWrapper}>
             <IconButton
               aria-label={transcriptTooltip}
               aria-expanded={transcriptOpen}
@@ -212,13 +199,39 @@ export function SessionControls({
                 onToggleTranscript();
               }}
               size="large"
+              className={styles.iconButton}
             >
               <SubjectIcon fontSize="inherit" />
             </IconButton>
           </span>
         </Tooltip>
+        <Tooltip title={themeTooltip} placement="left">
+          <span className={styles.iconWrapper}>
+            <IconButton
+              aria-label={themeTooltip}
+              aria-pressed={resolvedThemeMode === "dark"}
+              className={styles.iconButton}
+              color="default"
+              disabled={themeDisabled}
+              onClick={(event) => {
+                event.preventDefault();
+                if (themeDisabled) {
+                  return;
+                }
+                onToggleTheme?.();
+              }}
+              size="large"
+            >
+              {resolvedThemeMode === "dark" ? (
+                <LightModeIcon fontSize="inherit" />
+              ) : (
+                <DarkModeIcon fontSize="inherit" />
+              )}
+            </IconButton>
+          </span>
+        </Tooltip>
         <VoiceActivityIndicator active={voiceActive} hasMetrics={voiceHasMetrics} />
-      </Stack>
+      </div>
 
       <Snackbar
         open={Boolean(feedback)}

--- a/app/components/controls.module.css
+++ b/app/components/controls.module.css
@@ -1,0 +1,80 @@
+.rail {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: clamp(0.65rem, 1.8vw, 1rem);
+  padding: clamp(0.6rem, 1.2vw, 0.85rem) clamp(0.3rem, 1vw, 0.5rem)
+    clamp(0.6rem, 1.2vw, 0.85rem) clamp(0.4rem, 0.9vw, 0.65rem);
+  min-width: clamp(3.25rem, 5vw, 3.75rem);
+}
+
+.iconWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.iconButton {
+  width: clamp(2.75rem, 4vw, 3.1rem);
+  height: clamp(2.75rem, 4vw, 3.1rem);
+  border-radius: 999px;
+  box-shadow: none;
+  background: transparent;
+  margin: 0;
+}
+
+.iconButton:focus-visible {
+  outline: 3px solid currentColor;
+  outline-offset: 4px;
+}
+
+.iconButton:disabled {
+  opacity: 0.5;
+}
+
+.voiceIndicator {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(1.6rem, 2.5vw, 1.9rem);
+  height: clamp(1.6rem, 2.5vw, 1.9rem);
+  border-radius: 999px;
+  padding: 0;
+}
+
+.voiceIndicatorCore {
+  width: clamp(0.85rem, 1.6vw, 1.05rem);
+  height: clamp(0.85rem, 1.6vw, 1.05rem);
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.45);
+  box-shadow: 0 0 0 0 rgba(148, 163, 184, 0.35);
+  transition: background 200ms ease, box-shadow 200ms ease;
+}
+
+.voiceIndicator[data-ready="false"] .voiceIndicatorCore {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.voiceIndicator[data-ready="true"] .voiceIndicatorCore {
+  background: rgba(148, 163, 184, 0.55);
+  box-shadow: 0 0 6px rgba(148, 163, 184, 0.35);
+}
+
+.voiceIndicator[data-active="true"] .voiceIndicatorCore {
+  background: rgba(239, 68, 68, 0.95);
+  box-shadow: 0 0 12px rgba(239, 68, 68, 0.5);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/sdd/features/ui-streamlining-and-cleanup/tasks.md
+++ b/sdd/features/ui-streamlining-and-cleanup/tasks.md
@@ -25,7 +25,7 @@ Stretch the chat experience to fill the browser window in both dimensions and in
 ---
 
 ## Task T002: Rebuild Edge-Aligned Control Rail
-**Status:** Pending
+**Status:** Completed
 **Dependencies:** T001
 **Files:**
 - `app/components/SessionControls.tsx`

--- a/tests/chat/session-controls.test.tsx
+++ b/tests/chat/session-controls.test.tsx
@@ -16,6 +16,8 @@ type RenderProps = {
   onFeedbackClose?: () => void;
   transcriptOpen?: boolean;
   onToggleTranscript?: () => void;
+  themeMode?: "light" | "dark";
+  onToggleTheme?: () => void;
 };
 
 function renderSessionControls({
@@ -28,6 +30,8 @@ function renderSessionControls({
   onFeedbackClose = jest.fn(),
   transcriptOpen = false,
   onToggleTranscript = jest.fn(),
+  themeMode = "light",
+  onToggleTheme,
 }: RenderProps = {}) {
   const theme = createTheme();
   const result = render(
@@ -44,6 +48,8 @@ function renderSessionControls({
         voiceHasMetrics={false}
         transcriptOpen={transcriptOpen}
         onToggleTranscript={onToggleTranscript}
+        themeMode={themeMode}
+        onToggleTheme={onToggleTheme}
       />
     </ThemeProvider>,
   );
@@ -55,6 +61,7 @@ function renderSessionControls({
     onToggleMute,
     onFeedbackClose,
     onToggleTranscript,
+    onToggleTheme,
   };
 }
 
@@ -150,5 +157,18 @@ describe("SessionControls", () => {
     );
 
     expect(onToggleTranscript).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders theme toggle placeholder disabled by default", () => {
+    renderSessionControls();
+
+    const themeButton = screen.getByRole("button", { name: /switch to dark mode/i });
+    expect(themeButton).toBeDisabled();
+  });
+
+  it("exposes edge-aligned metadata for layout styling", () => {
+    renderSessionControls();
+
+    expect(screen.getByTestId("session-controls")).toHaveAttribute("data-align", "edge");
   });
 });


### PR DESCRIPTION
## Summary
- collapse `SessionControls` into a flush right-edge icon column with dedicated styles module
- remove visible labels/frames, add theme-toggle placeholder, and holistically restyle the voice indicator
- extend Jest coverage to assert aria/tooltips remain and verify edge-aligned metadata

## Testing
- npm test

Closes #26
