### PR TITLE
feat: add lightning entry flow overlay

### DIFF
--- a/app/chat-client.module.css
+++ b/app/chat-client.module.css
@@ -60,6 +60,7 @@
   height: 100%;
   max-height: 100%;
   overflow: auto;
+  position: relative;
 }
 
 .header {
@@ -97,6 +98,68 @@
   flex-direction: column;
   gap: 0.5rem;
   max-width: 28rem;
+}
+
+.entryOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  pointer-events: none;
+  padding: clamp(1.5rem, 4vw, 2rem);
+}
+
+.entryOverlay[data-visible="false"] {
+  display: none;
+}
+
+.entryButton {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(5.75rem, 12vw, 8rem);
+  height: clamp(5.75rem, 12vw, 8rem);
+  border-radius: 32px;
+  border: none;
+  background: linear-gradient(135deg, rgba(248, 250, 252, 0.9), rgba(226, 232, 240, 0.85));
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.15);
+  color: var(--mui-palette-warning-main, #f59e0b);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.entryButton:focus-visible {
+  outline: 4px solid var(--mui-palette-primary-main, #2563eb);
+  outline-offset: 6px;
+}
+
+.entryButton:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.entryButton:not(:disabled):hover {
+  transform: scale(1.05);
+  box-shadow: 0 28px 56px rgba(15, 23, 42, 0.18);
+}
+
+.entryHint,
+.entryError {
+  pointer-events: auto;
+  text-align: center;
+  max-width: clamp(20rem, 34vw, 28rem);
+}
+
+.entryHint {
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.entryError {
+  color: var(--mui-palette-error-main, #b91c1c);
 }
 
 

--- a/app/chat-client.tsx
+++ b/app/chat-client.tsx
@@ -10,6 +10,7 @@ import {
   SessionFeedback,
   ConnectionStatus,
 } from "./components/SessionControls";
+import { EntryOverlay } from "./components/EntryOverlay";
 import { TranscriptDrawer } from "./components/TranscriptDrawer";
 import { TranscriptStore, type TranscriptEntry } from "./lib/transcript-store";
 import { logTelemetry, type TelemetryTransport } from "./lib/analytics";
@@ -463,6 +464,7 @@ export function ChatClient() {
       data-dimmed={isDimmed ? "true" : "false"}
     >
       <main className={styles.canvas} aria-labelledby="chat-title">
+        <EntryOverlay status={status} error={error} onConnect={handleConnect} />
         <header className={styles.header}>
           <Typography
             id="chat-title"

--- a/app/components/EntryOverlay.tsx
+++ b/app/components/EntryOverlay.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import BoltIcon from "@mui/icons-material/Bolt";
+import Typography from "@mui/material/Typography";
+import { ConnectionStatus } from "./SessionControls";
+import styles from "../chat-client.module.css";
+
+type EntryOverlayProps = {
+  status: ConnectionStatus;
+  error: string | null;
+  onConnect: () => void | Promise<void>;
+};
+
+const statusCopy: Record<ConnectionStatus, string> = {
+  idle: "Start a realtime session",
+  connecting: "Connecting to realtime session…",
+  connected: "",
+  error: "Tap to retry connection",
+};
+
+export function EntryOverlay({ status, error, onConnect }: EntryOverlayProps) {
+  const isConnected = status === "connected";
+  const isConnecting = status === "connecting";
+  const isError = status === "error";
+  const copy = statusCopy[status] ?? "Start a realtime session";
+
+  if (isConnected) {
+    return null;
+  }
+
+  return (
+    <div className={styles.entryOverlay} data-visible={!isConnected}>
+      <Tooltip title={isConnecting ? "Connecting…" : "Connect"} placement="top">
+        <span>
+          <IconButton
+            className={styles.entryButton}
+            aria-label={isConnecting ? "Connecting" : "Start voice session"}
+            size="large"
+            disabled={isConnecting}
+            onClick={(event) => {
+              event.preventDefault();
+              if (isConnecting) {
+                return;
+              }
+              void onConnect();
+            }}
+          >
+            {isConnecting ? (
+              <CircularProgress size="3.5rem" thickness={3.5} />
+            ) : (
+              <BoltIcon sx={{ fontSize: "3.5rem" }} />
+            )}
+          </IconButton>
+        </span>
+      </Tooltip>
+      <Typography variant="h6" className={styles.entryHint} component="p">
+        {copy}
+      </Typography>
+      {isError && error ? (
+        <Typography variant="body2" className={styles.entryError} role="alert">
+          {error}
+        </Typography>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/SessionControls.tsx
+++ b/app/components/SessionControls.tsx
@@ -2,12 +2,10 @@
 
 import { MouseEvent, SyntheticEvent } from "react";
 import Alert from "@mui/material/Alert";
-import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
 import Snackbar from "@mui/material/Snackbar";
 import Tooltip from "@mui/material/Tooltip";
-import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
-import PowerOffIcon from "@mui/icons-material/PowerOff";
+import LogoutIcon from "@mui/icons-material/Logout";
 import MicIcon from "@mui/icons-material/Mic";
 import MicOffIcon from "@mui/icons-material/MicOff";
 import SubjectIcon from "@mui/icons-material/Subject";
@@ -70,7 +68,7 @@ function VoiceActivityIndicator({ active, hasMetrics }: VoiceActivityIndicatorPr
 
 export function SessionControls({
   status,
-  onConnect,
+  onConnect: _onConnect,
   onDisconnect,
   muted,
   onToggleMute,
@@ -85,15 +83,6 @@ export function SessionControls({
 }: SessionControlsProps) {
   const isConnecting = status === "connecting";
   const isConnected = status === "connected";
-  const isError = status === "error";
-
-  const tooltipTitle = isConnected
-    ? "Disconnect session"
-    : isConnecting
-      ? "Connecting…"
-      : isError
-        ? "Reconnect to session"
-        : "Connect to session";
 
   const micTooltip = !isConnected
     ? "Connect to enable microphone"
@@ -109,22 +98,13 @@ export function SessionControls({
     resolvedThemeMode === "dark" ? "Switch to light mode" : "Switch to dark mode";
   const themeDisabled = typeof onToggleTheme !== "function";
 
-  const iconColor = isConnected ? "success" : isError ? "error" : "primary";
+  const disconnectColor = "error";
   const micColor = muted ? "error" : "primary";
   const micDisabled = !isConnected || isConnecting;
 
-  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleDisconnectClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    if (isConnecting) {
-      return;
-    }
-
-    if (isConnected) {
-      onDisconnect();
-      return;
-    }
-
-    onConnect();
+    onDisconnect();
   };
 
   const handleSnackbarClose = (_: SyntheticEvent | Event, reason?: string) => {
@@ -137,31 +117,22 @@ export function SessionControls({
   return (
     <>
       <div className={styles.rail} data-testid="session-controls" data-align="edge">
-        <Tooltip title={tooltipTitle} placement="left">
-          <span className={styles.iconWrapper}>
-            <IconButton
-              aria-label={tooltipTitle}
-              aria-pressed={isConnected}
-              color={iconColor}
-              disabled={isConnecting}
-              onClick={handleClick}
-              size="large"
-              className={styles.iconButton}
-            >
-              {isConnecting ? (
-                <CircularProgress
-                  size={26}
-                  role="progressbar"
-                  aria-label="Connecting"
-                />
-              ) : isConnected ? (
-                <PowerOffIcon fontSize="inherit" />
-              ) : (
-                <PowerSettingsNewIcon fontSize="inherit" />
-              )}
-            </IconButton>
-          </span>
-        </Tooltip>
+        {isConnected ? (
+          <Tooltip title="Disconnect session" placement="left">
+            <span className={styles.iconWrapper}>
+              <IconButton
+                aria-label="Disconnect session"
+                aria-pressed
+                color={disconnectColor}
+                onClick={handleDisconnectClick}
+                size="large"
+                className={styles.iconButton}
+              >
+                <LogoutIcon fontSize="inherit" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        ) : null}
         <Tooltip title={micTooltip} placement="left">
           <span className={styles.iconWrapper}>
             <IconButton

--- a/sdd/features/ui-streamlining-and-cleanup/tasks.md
+++ b/sdd/features/ui-streamlining-and-cleanup/tasks.md
@@ -47,7 +47,7 @@ Refactor the control rail into a minimalist right-edge icon stack, remove visibl
 ---
 
 ## Task T003: Implement Lightning Entry Flow
-**Status:** Pending
+**Status:** Completed
 **Dependencies:** T001
 **Files:**
 - `app/chat-client.tsx`

--- a/tests/chat/entry-flow.test.tsx
+++ b/tests/chat/entry-flow.test.tsx
@@ -1,0 +1,153 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import Providers from "../../app/providers";
+import { ChatClient } from "../../app/chat-client";
+
+type MockRealtimeSession = {
+  connect: jest.Mock<Promise<void>, []>;
+  close: jest.Mock<void, []>;
+  mute: jest.Mock<void, [boolean]>;
+  muted: boolean;
+  history: unknown[];
+  on: jest.Mock;
+  off: jest.Mock;
+  getLatestAudioLevel: jest.Mock<number | null, []>;
+};
+
+const sessionInstances: MockRealtimeSession[] = [];
+const originalFetch = global.fetch;
+let nextConnectError: Error | null = null;
+
+jest.mock("@openai/agents/realtime", () => {
+  class MockSession {
+    connect = jest.fn().mockImplementation(async () => {
+      if (nextConnectError) {
+        const error = nextConnectError;
+        nextConnectError = null;
+        throw error;
+      }
+    });
+
+    close = jest.fn();
+
+    mute = jest.fn();
+
+    muted = false;
+
+    history: unknown[] = [];
+
+    on = jest.fn();
+
+    off = jest.fn();
+
+    getLatestAudioLevel = jest.fn().mockReturnValue(null);
+  }
+
+  return {
+    RealtimeAgent: jest.fn().mockImplementation(() => ({})),
+    RealtimeSession: jest.fn().mockImplementation(() => {
+      const instance = new MockSession() as MockRealtimeSession;
+      sessionInstances.push(instance);
+      return instance;
+    }),
+    OpenAIRealtimeWebRTC: jest
+      .fn()
+      .mockImplementation((options?: { audioElement?: HTMLAudioElement }) => ({
+        options,
+      })),
+  };
+});
+
+const fetchMock = jest.fn();
+
+describe("ChatClient lightning entry overlay", () => {
+  beforeEach(() => {
+    sessionInstances.length = 0;
+    nextConnectError = null;
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: "test-token" }),
+    });
+
+    // @ts-expect-error override fetch for test environment
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("shows the lightning overlay by default and hides it after connecting", async () => {
+    render(
+      <Providers>
+        <ChatClient />
+      </Providers>,
+    );
+
+    const entryButton = screen.getByRole("button", { name: /start voice session/i });
+    fireEvent.click(entryButton);
+
+    await waitFor(() => expect(sessionInstances.length).toBe(1));
+    const session = sessionInstances[0];
+    await waitFor(() => expect(session.connect).toHaveBeenCalledTimes(1));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /start voice session/i }),
+      ).not.toBeInTheDocument(),
+    );
+
+    expect(
+      screen.getByRole("button", { name: /disconnect session/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("restores the overlay after disconnect", async () => {
+    render(
+      <Providers>
+        <ChatClient />
+      </Providers>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /start voice session/i }));
+
+    await waitFor(() => expect(sessionInstances.length).toBe(1));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /start voice session/i }),
+      ).not.toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /disconnect session/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /start voice session/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces connection errors on the overlay", async () => {
+    render(
+      <Providers>
+        <ChatClient />
+      </Providers>,
+    );
+
+    nextConnectError = new Error("forbidden");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start voice session/i }));
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /start voice session/i }),
+      ).toBeEnabled(),
+    );
+
+    await waitFor(() => expect(screen.queryAllByText(/forbidden/i).length).toBeGreaterThan(0));
+  });
+});

--- a/tests/chat/layout-dimming.test.tsx
+++ b/tests/chat/layout-dimming.test.tsx
@@ -119,7 +119,7 @@ describe("UI streamlining viewport and dimming behaviour", () => {
     const layout = document.querySelector("[data-dimmed]");
     expect(layout).toHaveAttribute("data-dimmed", "true");
 
-    fireEvent.click(screen.getByRole("button", { name: /connect to session/i }));
+    fireEvent.click(screen.getByRole("button", { name: /start voice session/i }));
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /disconnect session/i })).toBeInTheDocument(),
@@ -130,7 +130,7 @@ describe("UI streamlining viewport and dimming behaviour", () => {
     fireEvent.click(screen.getByRole("button", { name: /disconnect session/i }));
 
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: /connect to session/i })).toBeInTheDocument(),
+      expect(screen.getByRole("button", { name: /start voice session/i })).toBeInTheDocument(),
     );
 
     expect(layout).toHaveAttribute("data-dimmed", "true");

--- a/tests/chat/mic-toggle.test.tsx
+++ b/tests/chat/mic-toggle.test.tsx
@@ -80,7 +80,7 @@ describe("ChatClient microphone toggle", () => {
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: /connect to session/i }),
+      screen.getByRole("button", { name: /start voice session/i }),
     );
 
     await waitFor(() => expect(sessionInstances.length).toBe(1));

--- a/tests/chat/session-controls.test.tsx
+++ b/tests/chat/session-controls.test.tsx
@@ -56,7 +56,6 @@ function renderSessionControls({
 
   return {
     ...result,
-    onConnect,
     onDisconnect,
     onToggleMute,
     onFeedbackClose,
@@ -66,16 +65,6 @@ function renderSessionControls({
 }
 
 describe("SessionControls", () => {
-  it("invokes connect handler when disconnected", () => {
-    const { onConnect } = renderSessionControls();
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /connect to session/i }),
-    );
-
-    expect(onConnect).toHaveBeenCalledTimes(1);
-  });
-
   it("invokes disconnect handler when connected", () => {
     const { onDisconnect } = renderSessionControls({ status: "connected" });
 
@@ -86,23 +75,12 @@ describe("SessionControls", () => {
     expect(onDisconnect).toHaveBeenCalledTimes(1);
   });
 
-  it("does not trigger handlers while connecting", () => {
-    const { onConnect, onDisconnect } = renderSessionControls({
-      status: "connecting",
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: /connecting/i }));
-
-    expect(onConnect).not.toHaveBeenCalled();
-    expect(onDisconnect).not.toHaveBeenCalled();
-  });
-
-  it("indicates error state via reconnect tooltip", () => {
-    renderSessionControls({ status: "error" });
+  it("hides the disconnect control until a session is connected", () => {
+    renderSessionControls();
 
     expect(
-      screen.getByRole("button", { name: /reconnect to session/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /disconnect session/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders snackbar feedback and closes via the dismiss action", () => {

--- a/tests/chat/telemetry.test.tsx
+++ b/tests/chat/telemetry.test.tsx
@@ -115,7 +115,7 @@ describe("ChatClient telemetry", () => {
   it("emits events for successful connect flow", async () => {
     renderClient();
 
-    const connectButton = screen.getByRole("button", { name: /connect to session/i });
+    const connectButton = screen.getByRole("button", { name: /start voice session/i });
     fireEvent.click(connectButton);
 
     await waitFor(() => expect(activeSession.connect).toHaveBeenCalledTimes(1));
@@ -141,7 +141,7 @@ describe("ChatClient telemetry", () => {
 
     renderClient();
 
-    const connectButton = screen.getByRole("button", { name: /connect to session/i });
+    const connectButton = screen.getByRole("button", { name: /start voice session/i });
     await act(async () => {
       fireEvent.click(connectButton);
     });
@@ -158,7 +158,7 @@ describe("ChatClient telemetry", () => {
   it("logs mute and transcript interactions", async () => {
     renderClient();
 
-    const connectButton = screen.getByRole("button", { name: /connect to session/i });
+    const connectButton = screen.getByRole("button", { name: /start voice session/i });
     fireEvent.click(connectButton);
     await waitFor(() => expect(activeSession.connect).toHaveBeenCalledTimes(1));
 
@@ -187,7 +187,7 @@ describe("ChatClient telemetry", () => {
   it("logs disconnect telemetry", async () => {
     renderClient();
 
-    const connectButton = screen.getByRole("button", { name: /connect to session/i });
+    const connectButton = screen.getByRole("button", { name: /start voice session/i });
     fireEvent.click(connectButton);
     await waitFor(() => expect(activeSession.connect).toHaveBeenCalledTimes(1));
 

--- a/tests/chat/voice-meter.test.tsx
+++ b/tests/chat/voice-meter.test.tsx
@@ -75,7 +75,7 @@ describe("ChatClient voice meter", () => {
       </Providers>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /connect to session/i }));
+    fireEvent.click(screen.getByRole("button", { name: /start voice session/i }));
 
     await waitFor(() => expect(sessionInstances.length).toBe(1));
     const session = sessionInstances[0];


### PR DESCRIPTION
## Summary
- introduce a centered lightning entry overlay that handles connect/retry states and dims the canvas until the session is live
- hide the side-rail connect control until connected, swap to a logout-style disconnect icon, and refine supporting styles
- adjust Jest suites to interact with the new overlay and verify error handling and disconnect flow

## Testing
- npm test

Closes #28
