### PR TITLE
feat: add theme toggle persistence

### DIFF
--- a/app/chat-client.module.css
+++ b/app/chat-client.module.css
@@ -7,7 +7,7 @@
   height: 100vh;
   min-width: 100vw;
   min-height: 100vh;
-  background-color: var(--mui-palette-background-default, #ffffff);
+  background-color: var(--vc-background, var(--mui-palette-background-default, #f5f7fa));
   overflow: hidden;
 }
 
@@ -155,7 +155,7 @@
 }
 
 .entryHint {
-  color: rgba(15, 23, 42, 0.75);
+  color: var(--mui-palette-text-secondary, rgba(148, 163, 184, 0.9));
 }
 
 .entryError {

--- a/app/chat-client.tsx
+++ b/app/chat-client.tsx
@@ -5,16 +5,13 @@ import Typography from "@mui/material/Typography";
 import { RealtimeAgent, RealtimeSession } from "@openai/agents/realtime";
 import styles from "./chat-client.module.css";
 
-import {
-  SessionControls,
-  SessionFeedback,
-  ConnectionStatus,
-} from "./components/SessionControls";
+import { SessionControls, SessionFeedback, ConnectionStatus } from "./components/SessionControls";
 import { EntryOverlay } from "./components/EntryOverlay";
 import { TranscriptDrawer } from "./components/TranscriptDrawer";
 import { TranscriptStore, type TranscriptEntry } from "./lib/transcript-store";
 import { logTelemetry, type TelemetryTransport } from "./lib/analytics";
 import { createRealtimeSession } from "./lib/realtime-session-factory";
+import { useThemeController } from "./providers";
 
 type VoiceActivityState = {
   level: number;
@@ -40,6 +37,7 @@ const clampLevel = (value: number) => {
 };
 
 export function ChatClient() {
+  const { mode: themeMode, toggle: toggleTheme } = useThemeController();
   const [status, setStatus] = useState<ConnectionStatus>("idle");
   const [error, setError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<SessionFeedback | null>(null);
@@ -460,6 +458,7 @@ export function ChatClient() {
   return (
     <div
       className={styles.layout}
+      data-testid="chat-layout"
       data-layout={isCompactLayout ? "compact" : "wide"}
       data-dimmed={isDimmed ? "true" : "false"}
     >
@@ -518,6 +517,8 @@ export function ChatClient() {
             voiceLevel={voiceActivity.level}
             transcriptOpen={isTranscriptOpen}
             onToggleTranscript={handleToggleTranscript}
+            themeMode={themeMode}
+            onToggleTheme={toggleTheme}
           />
         </div>
       </aside>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,5 @@
 :root {
-  color-scheme: light;
+  color-scheme: var(--vc-color-scheme, light);
 }
 
 * {
@@ -19,7 +19,7 @@ body.vc-body {
   min-height: 100vh;
   min-width: 100vw;
   width: 100%;
-  background-color: var(--mui-palette-background-default, #ffffff);
+  background-color: var(--vc-background, #ffffff);
   overflow: hidden;
 }
 

--- a/app/lib/theme-store.ts
+++ b/app/lib/theme-store.ts
@@ -1,0 +1,127 @@
+export type ThemeMode = "light" | "dark";
+
+const STORAGE_KEY = "vc-theme-mode";
+
+const isBrowser = () => typeof window !== "undefined";
+
+const isThemeMode = (value: unknown): value is ThemeMode =>
+  value === "light" || value === "dark";
+
+const readPersistedMode = (): ThemeMode | null => {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY);
+    return isThemeMode(value) ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+const writePersistedMode = (mode: ThemeMode) => {
+  if (!isBrowser()) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // Ignore write failures (e.g., private mode, storage disabled)
+  }
+};
+
+const getPreferredMode = (): ThemeMode => {
+  if (!isBrowser()) {
+    return "light";
+  }
+
+  try {
+    if (typeof window.matchMedia === "function") {
+      const query = window.matchMedia("(prefers-color-scheme: dark)");
+      return query.matches ? "dark" : "light";
+    }
+  } catch {
+    // Ignore media query failures
+  }
+
+  return "light";
+};
+
+export class ThemeStore {
+  private mode: ThemeMode;
+  private listeners = new Set<(mode: ThemeMode) => void>();
+  private hydrated = false;
+
+  constructor(initialMode: ThemeMode = "light") {
+    this.mode = initialMode;
+  }
+
+  getMode(): ThemeMode {
+    return this.mode;
+  }
+
+  setMode(mode: ThemeMode, options?: { persist?: boolean }) {
+    if (!isThemeMode(mode)) {
+      return;
+    }
+
+    if (this.mode === mode) {
+      return;
+    }
+
+    this.mode = mode;
+    if (options?.persist !== false) {
+      writePersistedMode(mode);
+    }
+    this.notify();
+  }
+
+  toggle() {
+    this.setMode(this.mode === "dark" ? "light" : "dark");
+  }
+
+  hydrate(): ThemeMode {
+    if (this.hydrated) {
+      return this.mode;
+    }
+
+    this.hydrated = true;
+    const persisted = readPersistedMode();
+    if (persisted) {
+      if (persisted !== this.mode) {
+        this.mode = persisted;
+        this.notify();
+      }
+      return this.mode;
+    }
+
+    const preferred = getPreferredMode();
+    if (preferred !== this.mode) {
+      this.mode = preferred;
+      this.notify();
+    }
+    return this.mode;
+  }
+
+  subscribe(listener: (mode: ThemeMode) => void) {
+    this.listeners.add(listener);
+    listener(this.mode);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private notify() {
+    this.listeners.forEach((listener) => {
+      listener(this.mode);
+    });
+  }
+}
+
+export const __storage = {
+  key: STORAGE_KEY,
+  read: readPersistedMode,
+  write: writePersistedMode,
+};

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,14 +1,84 @@
-'use client';
+"use client";
 
-import { CssBaseline, ThemeProvider } from '@mui/material';
-import type { PropsWithChildren } from 'react';
-import theme from './theme';
+import { CssBaseline, ThemeProvider } from "@mui/material";
+import type { PropsWithChildren } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createAppTheme } from "./theme";
+import { ThemeStore, type ThemeMode } from "./lib/theme-store";
+
+type ThemeController = {
+  mode: ThemeMode;
+  toggle: () => void;
+  setMode: (mode: ThemeMode) => void;
+};
+
+const ThemeControllerContext = createContext<ThemeController | null>(null);
+
+export const useThemeController = () => {
+  const context = useContext(ThemeControllerContext);
+  if (!context) {
+    throw new Error("useThemeController must be used within Providers");
+  }
+  return context;
+};
 
 export default function Providers({ children }: PropsWithChildren) {
+  const themeStoreRef = useRef<ThemeStore>();
+
+  if (!themeStoreRef.current) {
+    themeStoreRef.current = new ThemeStore();
+  }
+
+  const themeStore = themeStoreRef.current;
+  const [mode, setMode] = useState<ThemeMode>(() => themeStore.getMode());
+
+  useEffect(() => {
+    const unsubscribe = themeStore.subscribe((nextMode) => {
+      setMode(nextMode);
+    });
+
+    themeStore.hydrate();
+    return unsubscribe;
+  }, [themeStore]);
+
+  const handleToggle = useCallback(() => {
+    themeStore.toggle();
+  }, [themeStore]);
+
+  const handleSetMode = useCallback((nextMode: ThemeMode) => {
+    themeStore.setMode(nextMode);
+  }, [themeStore]);
+
+  const theme = useMemo(() => createAppTheme(mode), [mode]);
+
+  const controller = useMemo(
+    () => ({
+      mode,
+      toggle: handleToggle,
+      setMode: handleSetMode,
+    }),
+    [handleSetMode, handleToggle, mode],
+  );
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    document.documentElement.style.setProperty("--vc-color-scheme", mode);
+    document.documentElement.style.colorScheme = mode;
+    const background = theme.palette.background.default;
+    document.body.style.setProperty("--vc-background", background);
+    document.body.style.backgroundColor = background;
+    document.documentElement.style.backgroundColor = background;
+  }, [mode, theme]);
+
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      {children}
-    </ThemeProvider>
+    <ThemeControllerContext.Provider value={controller}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </ThemeControllerContext.Provider>
   );
 }

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -1,25 +1,45 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme } from "@mui/material/styles";
+import type { ThemeMode } from "./lib/theme-store";
 
-const theme = createTheme({
-  palette: {
-    mode: 'light',
-    background: {
-      default: '#ffffff',
-      paper: '#ffffff',
+const backgroundByMode: Record<ThemeMode, { default: string; paper: string }> = {
+  light: {
+    default: "#f5f7fa",
+    paper: "#ffffff",
+  },
+  dark: {
+    default: "#050b19",
+    paper: "#0d1628",
+  },
+};
+
+export const createAppTheme = (mode: ThemeMode = "light") => {
+  const paletteBackground = backgroundByMode[mode] ?? backgroundByMode.light;
+
+  return createTheme({
+    palette: {
+      mode,
+      background: paletteBackground,
     },
-  },
-  typography: {
-    fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
-  },
-  components: {
-    MuiCssBaseline: {
-      styleOverrides: {
-        body: {
-          backgroundColor: '#ffffff',
+    shape: {
+      borderRadius: 12,
+    },
+    typography: {
+      fontFamily: "Roboto, Helvetica, Arial, sans-serif",
+    },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            backgroundColor: paletteBackground.default,
+            transition: "background-color 240ms ease, color 240ms ease",
+          },
+          "*": {
+            transition: "background-color 240ms ease, color 240ms ease",
+          },
         },
       },
     },
-  },
-});
+  });
+};
 
-export default theme;
+export default createAppTheme();

--- a/tests/chat/session-controls.test.tsx
+++ b/tests/chat/session-controls.test.tsx
@@ -140,11 +140,23 @@ describe("SessionControls", () => {
     expect(onToggleTranscript).toHaveBeenCalledTimes(1);
   });
 
-  it("renders theme toggle placeholder disabled by default", () => {
+  it("disables theme toggle when handler missing", () => {
     renderSessionControls();
 
     const themeButton = screen.getByRole("button", { name: /switch to dark mode/i });
     expect(themeButton).toBeDisabled();
+  });
+
+  it("enables theme toggle when handler provided", () => {
+    const onToggleTheme = jest.fn();
+    renderSessionControls({ onToggleTheme });
+
+    const themeButton = screen.getByRole("button", { name: /switch to dark mode/i });
+    expect(themeButton).toBeEnabled();
+
+    fireEvent.click(themeButton);
+
+    expect(onToggleTheme).toHaveBeenCalledTimes(1);
   });
 
   it("exposes edge-aligned metadata for layout styling", () => {

--- a/tests/chat/theme-toggle.test.tsx
+++ b/tests/chat/theme-toggle.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import Providers from "../../app/providers";
+import { ChatClient } from "../../app/chat-client";
+import { __storage } from "../../app/lib/theme-store";
+
+const originalFetch = global.fetch;
+
+jest.mock("@openai/agents/realtime", () => {
+  class MockSession {
+    connect = jest.fn().mockResolvedValue(undefined);
+
+    close = jest.fn();
+
+    mute = jest.fn();
+
+    muted = false;
+
+    history: unknown[] = [];
+  }
+
+  return {
+    RealtimeAgent: jest.fn().mockImplementation(() => ({})),
+    RealtimeSession: jest.fn().mockImplementation(() => new MockSession()),
+    OpenAIRealtimeWebRTC: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+describe("ChatClient theme toggle", () => {
+  beforeEach(() => {
+    window.localStorage?.clear();
+    // @ts-expect-error override fetch for test environment
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    window.localStorage?.clear();
+    global.fetch = originalFetch;
+  });
+
+  it("toggles between light and dark modes", () => {
+    render(
+      <Providers>
+        <ChatClient />
+      </Providers>,
+    );
+
+    const toggle = screen.getByRole("button", { name: /switch to dark mode/i });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+    expect(toggle).toBeEnabled();
+
+    const initialBackground = window.getComputedStyle(document.body).backgroundColor;
+
+    fireEvent.click(toggle);
+
+    const toggled = screen.getByRole("button", { name: /switch to light mode/i });
+    expect(toggled).toHaveAttribute("aria-pressed", "true");
+    const darkBackground = window.getComputedStyle(document.body).backgroundColor;
+    expect(darkBackground).not.toEqual(initialBackground);
+  });
+
+  it("persists the selected theme across reloads", () => {
+    const { unmount } = render(
+      <Providers>
+        <ChatClient />
+      </Providers>,
+    );
+
+    const toggle = screen.getByRole("button", { name: /switch to dark mode/i });
+    fireEvent.click(toggle);
+
+    expect(window.localStorage?.getItem(__storage.key)).toBe("dark");
+    const darkBackground = window.getComputedStyle(document.body).backgroundColor;
+
+    unmount();
+
+    render(
+      <Providers>
+        <ChatClient />
+      </Providers>,
+    );
+
+    const restored = screen.getByRole("button", { name: /switch to light mode/i });
+    expect(restored).toHaveAttribute("aria-pressed", "true");
+    const restoredBackground = window.getComputedStyle(document.body).backgroundColor;
+    expect(restoredBackground).toEqual(darkBackground);
+  });
+
+  it("leaves dimmed entry state unaffected by theme toggling", () => {
+    render(
+      <Providers>
+        <ChatClient />
+      </Providers>,
+    );
+
+    const layout = screen.getByTestId("chat-layout");
+    expect(layout).toHaveAttribute("data-dimmed", "true");
+
+    const toggle = screen.getByRole("button", { name: /switch to dark mode/i });
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole("button", { name: /switch to light mode/i })).toBeEnabled();
+    expect(layout).toHaveAttribute("data-dimmed", "true");
+    expect(
+      screen.getByRole("button", { name: /start voice session/i }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add theme store with persistence and hydration to sync MUI theme
- wire chat client controls to toggle light/dark modes with palette transitions
- cover theme toggling, persistence, and dim state via Jest tests

## Testing
- npm test

Closes #32