### PR TITLE
feat: add MCP server manager

### DIFF
--- a/app/lib/mcp/process-registry.ts
+++ b/app/lib/mcp/process-registry.ts
@@ -1,0 +1,98 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import type { McpServerDefinition } from './config';
+
+export type ServerLifecycleStatus =
+  | 'starting'
+  | 'running'
+  | 'restarting'
+  | 'stopped'
+  | 'error';
+
+export interface ExitSnapshot {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  at: number;
+}
+
+interface ServerProcessState {
+  definition: McpServerDefinition;
+  process?: ChildProcessWithoutNullStreams;
+  status: ServerLifecycleStatus;
+  restarts: number;
+  lastExit?: ExitSnapshot;
+  lastStartedAt?: number;
+}
+
+export interface ServerStatusSnapshot {
+  id: string;
+  definition: McpServerDefinition;
+  status: ServerLifecycleStatus;
+  restarts: number;
+  lastExit?: ExitSnapshot;
+  lastStartedAt?: number;
+  pid?: number;
+}
+
+export class ProcessRegistry {
+  private readonly processes = new Map<string, ServerProcessState>();
+
+  ensure(definition: McpServerDefinition): ServerProcessState {
+    const existing = this.processes.get(definition.id);
+    if (existing) {
+      existing.definition = definition;
+      return existing;
+    }
+
+    const state: ServerProcessState = {
+      definition,
+      status: 'starting',
+      restarts: 0,
+    };
+    this.processes.set(definition.id, state);
+    return state;
+  }
+
+  update(
+    id: string,
+    updates: Partial<Omit<ServerProcessState, 'definition'>>,
+  ): ServerProcessState | undefined {
+    const current = this.processes.get(id);
+    if (!current) {
+      return undefined;
+    }
+
+    Object.assign(current, updates);
+    return current;
+  }
+
+  incrementRestarts(id: string): number {
+    const current = this.processes.get(id);
+    if (!current) {
+      throw new Error(`Cannot increment restarts for unknown server "${id}"`);
+    }
+
+    current.restarts += 1;
+    return current.restarts;
+  }
+
+  remove(id: string): void {
+    this.processes.delete(id);
+  }
+
+  get(id: string): ServerProcessState | undefined {
+    return this.processes.get(id);
+  }
+
+  list(): ServerStatusSnapshot[] {
+    return Array.from(this.processes.entries()).map(([id, state]) => ({
+      id,
+      definition: state.definition,
+      status: state.status,
+      restarts: state.restarts,
+      lastExit: state.lastExit,
+      lastStartedAt: state.lastStartedAt,
+      pid: state.process?.pid,
+    }));
+  }
+}

--- a/app/lib/mcp/serverManager.ts
+++ b/app/lib/mcp/serverManager.ts
@@ -1,0 +1,234 @@
+import { spawn } from 'node:child_process';
+import type {
+  ChildProcessWithoutNullStreams,
+  SpawnOptionsWithoutStdio,
+} from 'node:child_process';
+
+import {
+  loadMcpConfig,
+  type McpServerConfig,
+  type McpServerDefinition,
+} from './config';
+import {
+  ProcessRegistry,
+  type ServerLifecycleStatus,
+  type ServerStatusSnapshot,
+} from './process-registry';
+
+export interface McpServerManagerLogger {
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+  error?: (message: string) => void;
+}
+
+export interface McpServerManagerOptions {
+  configPath?: string;
+  logger?: McpServerManagerLogger;
+  spawn?: (
+    command: string,
+    args: readonly string[],
+    options: SpawnOptionsWithoutStdio,
+  ) => ChildProcessWithoutNullStreams;
+  loadConfig?: () => Promise<McpServerConfig>;
+  backoff?: {
+    initialMs?: number;
+    maxMs?: number;
+  };
+  env?: NodeJS.ProcessEnv;
+  now?: () => number;
+}
+
+const DEFAULT_BACKOFF_INITIAL = 1_000;
+const DEFAULT_BACKOFF_MAX = 30_000;
+
+type RestartTimer = NodeJS.Timeout;
+
+export class McpServerManager {
+  private readonly logger: Required<McpServerManagerLogger>;
+  private readonly registry = new ProcessRegistry();
+  private readonly restartTimers = new Map<string, RestartTimer>();
+  private readonly stopping = new Set<string>();
+  private readonly spawnFn: (
+    command: string,
+    args: readonly string[],
+    options: SpawnOptionsWithoutStdio,
+  ) => ChildProcessWithoutNullStreams;
+  private readonly loadConfigFn: () => Promise<McpServerConfig>;
+  private readonly backoffInitial: number;
+  private readonly backoffMax: number;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly now: () => number;
+  private started = false;
+  private shuttingDown = false;
+
+  constructor(private readonly options: McpServerManagerOptions = {}) {
+    const defaultLogger: Required<McpServerManagerLogger> = {
+      info: console.log.bind(console),
+      warn: console.warn.bind(console),
+      error: console.error.bind(console),
+    };
+    this.logger = {
+      info: options.logger?.info ?? defaultLogger.info,
+      warn: options.logger?.warn ?? defaultLogger.warn,
+      error: options.logger?.error ?? defaultLogger.error,
+    };
+    this.spawnFn = options.spawn ?? spawn;
+    this.now = options.now ?? Date.now;
+    this.loadConfigFn =
+      options.loadConfig ??
+      (async () =>
+        loadMcpConfig({
+          configPath: options.configPath,
+          logger: this.logger,
+        }));
+    this.backoffInitial = options.backoff?.initialMs ?? DEFAULT_BACKOFF_INITIAL;
+    this.backoffMax = options.backoff?.maxMs ?? DEFAULT_BACKOFF_MAX;
+    this.env = { ...process.env, ...options.env };
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      this.logger.warn?.('[mcp-server-manager] start called more than once');
+      return;
+    }
+
+    const config = await this.loadConfigFn();
+    this.started = true;
+    this.logger.info?.(
+      `[mcp-server-manager] starting ${config.servers.length} configured servers`,
+    );
+
+    config.servers
+      .filter((server) => server.enabled !== false)
+      .forEach((server) => this.launchServer(server));
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+
+    this.shuttingDown = true;
+    for (const timer of this.restartTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.restartTimers.clear();
+
+    const snapshots = this.registry.list();
+    snapshots.forEach(({ id }) => {
+      this.stopping.add(id);
+    });
+
+    snapshots.forEach(({ id }) => {
+      const state = this.registry.get(id);
+      if (!state?.process) {
+        this.registry.update(id, { status: 'stopped' });
+        return;
+      }
+
+      state.process.kill('SIGTERM');
+      this.registry.update(id, {
+        status: 'stopped',
+        process: undefined,
+      });
+    });
+
+    this.started = false;
+    this.shuttingDown = false;
+    this.logger.info?.('[mcp-server-manager] all servers stopped');
+  }
+
+  getStatuses(): ServerStatusSnapshot[] {
+    return this.registry.list();
+  }
+
+  private launchServer(definition: McpServerDefinition) {
+    const state = this.registry.ensure(definition);
+    this.stopping.delete(definition.id);
+
+    const child = this.spawnFn(definition.command, definition.args, {
+      stdio: 'pipe',
+      env: this.env,
+    });
+
+    this.registry.update(definition.id, {
+      process: child,
+      status: 'starting',
+      lastStartedAt: this.now(),
+    });
+
+    child.once('spawn', () => {
+      this.updateStatus(definition.id, 'running');
+      this.logger.info?.(
+        `[mcp-server-manager] server "${definition.id}" is running (pid ${child.pid ?? 'unknown'})`,
+      );
+    });
+
+    child.once('error', (error) => {
+      this.logger.error?.(
+        `[mcp-server-manager] server "${definition.id}" error: ${String(
+          error,
+        )}`,
+      );
+      this.handleExit(definition, null, null);
+    });
+
+    child.once('exit', (code, signal) => {
+      this.logger.warn?.(
+        `[mcp-server-manager] server "${definition.id}" exited (code ${code}, signal ${signal ?? 'none'})`,
+      );
+      this.handleExit(definition, code, signal);
+    });
+  }
+
+  private handleExit(
+    definition: McpServerDefinition,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ) {
+    const { id } = definition;
+    const state = this.registry.get(id);
+    if (!state) {
+      return;
+    }
+
+    this.registry.update(id, {
+      process: undefined,
+      lastExit: { code, signal, at: this.now() },
+    });
+
+    if (this.shuttingDown || this.stopping.has(id)) {
+      this.stopping.delete(id);
+      this.registry.update(id, { status: 'stopped' });
+      return;
+    }
+
+    const restarts = this.registry.incrementRestarts(id);
+    this.updateStatus(id, 'restarting');
+
+    const delay = Math.min(
+      this.backoffInitial * 2 ** (restarts - 1),
+      this.backoffMax,
+    );
+
+    this.logger.info?.(
+      `[mcp-server-manager] scheduling restart for "${id}" in ${delay}ms (attempt ${restarts})`,
+    );
+
+    const existingTimer = this.restartTimers.get(id);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
+    const timer = setTimeout(() => {
+      this.restartTimers.delete(id);
+      this.launchServer(definition);
+    }, delay);
+
+    this.restartTimers.set(id, timer);
+  }
+
+  private updateStatus(id: string, status: ServerLifecycleStatus) {
+    this.registry.update(id, { status });
+  }
+}

--- a/sdd/features/mcp-tools/tasks.md
+++ b/sdd/features/mcp-tools/tasks.md
@@ -25,7 +25,7 @@ Introduce a versioned config file that lists MCP servers as stdio shell commands
 ---
 
 ## Task T002: Manage MCP Server Processes
-**Status:** Pending
+**Status:** Completed
 **Dependencies:** T001
 **Files:**
 - `app/lib/mcp/serverManager.ts`

--- a/tests/mcp/server-manager.test.ts
+++ b/tests/mcp/server-manager.test.ts
@@ -1,0 +1,199 @@
+/** @jest-environment node */
+
+import { EventEmitter } from 'node:events';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { PassThrough } from 'node:stream';
+
+import { McpServerManager } from '@/app/lib/mcp/serverManager';
+
+type MockChildProcess = ChildProcessWithoutNullStreams &
+  EventEmitter & {
+    kill: jest.Mock<boolean, [NodeJS.Signals | number | undefined]>;
+  };
+
+const createMockChildProcess = (): MockChildProcess => {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough();
+  const child = Object.assign(new EventEmitter(), {
+    stdout,
+    stderr,
+    stdin,
+    kill: jest.fn().mockReturnValue(true),
+    pid: Math.floor(Math.random() * 10_000),
+    spawnfile: 'mock',
+    spawnargs: ['mock'],
+    connected: true,
+    killed: false,
+  });
+
+  return child as MockChildProcess;
+};
+
+const createLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('McpServerManager', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('spawns enabled servers and tracks status', async () => {
+    const child = createMockChildProcess();
+    const spawnMock = jest.fn().mockReturnValue(child);
+    const logger = createLogger();
+
+    const manager = new McpServerManager({
+      spawn: spawnMock,
+      loadConfig: async () => ({
+        servers: [
+          {
+            id: 'codex',
+            command: 'codex-tasks',
+            args: ['mcp'],
+            description: 'Codex tasks server',
+            enabled: true,
+          },
+          {
+            id: 'disabled',
+            command: 'noop',
+            args: [],
+            enabled: false,
+          },
+        ],
+      }),
+      env: { CUSTOM_VAR: 'value' },
+      logger,
+      now: () => 123,
+    });
+
+    await manager.start();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenCalledWith(
+      'codex-tasks',
+      ['mcp'],
+      expect.objectContaining({
+        stdio: 'pipe',
+      }),
+    );
+
+    const spawnOptions = spawnMock.mock.calls[0][2];
+    expect(spawnOptions.env).toMatchObject({ CUSTOM_VAR: 'value' });
+
+    let statuses = manager.getStatuses();
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0]).toMatchObject({
+      id: 'codex',
+      status: 'starting',
+      restarts: 0,
+    });
+
+    child.emit('spawn');
+
+    statuses = manager.getStatuses();
+    expect(statuses[0]).toMatchObject({
+      id: 'codex',
+      status: 'running',
+      restarts: 0,
+      lastStartedAt: 123,
+    });
+    expect(statuses[0].pid).toBe(child.pid);
+  });
+
+  it('restarts servers with backoff when they exit unexpectedly', async () => {
+    jest.useFakeTimers();
+    const child1 = createMockChildProcess();
+    const child2 = createMockChildProcess();
+    const spawnMock = jest
+      .fn()
+      .mockReturnValueOnce(child1)
+      .mockReturnValueOnce(child2);
+    const logger = createLogger();
+
+    const manager = new McpServerManager({
+      spawn: spawnMock,
+      loadConfig: async () => ({
+        servers: [
+          {
+            id: 'codex',
+            command: 'codex-tasks',
+            args: ['mcp'],
+            enabled: true,
+          },
+        ],
+      }),
+      logger,
+      backoff: { initialMs: 50, maxMs: 100 },
+    });
+
+    await manager.start();
+    child1.emit('spawn');
+
+    child1.emit('exit', 1, null);
+    let statuses = manager.getStatuses();
+    expect(statuses[0]).toMatchObject({
+      id: 'codex',
+      status: 'restarting',
+      restarts: 1,
+    });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(50);
+    await Promise.resolve();
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    child2.emit('spawn');
+    statuses = manager.getStatuses();
+    expect(statuses[0]).toMatchObject({
+      id: 'codex',
+      status: 'running',
+      restarts: 1,
+    });
+  });
+
+  it('stops servers gracefully and prevents restarts', async () => {
+    jest.useFakeTimers();
+    const child = createMockChildProcess();
+    const spawnMock = jest.fn().mockReturnValue(child);
+    const logger = createLogger();
+
+    const manager = new McpServerManager({
+      spawn: spawnMock,
+      loadConfig: async () => ({
+        servers: [
+          {
+            id: 'codex',
+            command: 'codex-tasks',
+            args: ['mcp'],
+            enabled: true,
+          },
+        ],
+      }),
+      logger,
+    });
+
+    await manager.start();
+    child.emit('spawn');
+
+    await manager.stop();
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+    child.emit('exit', null, 'SIGTERM');
+    jest.advanceTimersByTime(1_000);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const statuses = manager.getStatuses();
+    expect(statuses[0]).toMatchObject({
+      id: 'codex',
+      status: 'stopped',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add process registry to track MCP server lifecycle and restart metadata
- implement MCP server manager to spawn stdio servers with exponential backoff
- cover spawn, restart, and graceful shutdown via Jest mocks

Closes #43

## Testing
- npm test -- --runTestsByPath tests/mcp/config-validation.test.ts tests/mcp/server-manager.test.ts
