### PR TITLE
SDD: MCP catalog toast

### DIFF
--- a/app/chat-client.module.css
+++ b/app/chat-client.module.css
@@ -52,7 +52,7 @@
   display: flex;
   flex-direction: column;
   gap: clamp(1.5rem, 2vw, 2.5rem);
-  padding: clamp(2.5rem, 5vw, 3.75rem);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
   border-radius: 0;
   border: none;
   background-color: transparent;
@@ -66,12 +66,14 @@
 .header {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  max-width: 32rem;
+  align-items: flex-start;
+  gap: 0.25rem;
 }
 
 .title {
   font-weight: 600;
+  font-size: clamp(1.5rem, 2.6vw, 2.25rem);
+  line-height: 1.05;
 }
 
 .surface {

--- a/tests/e2e/mcp-tools.spec.ts
+++ b/tests/e2e/mcp-tools.spec.ts
@@ -38,7 +38,8 @@ test('MCP catalog handshake and tool invocation flow', async ({ page }) => {
 
   await page.goto('/');
 
-  await expect(page.getByTestId('mcp-tool-summary')).toHaveText(/MCP tools ready: 1/);
+  await expect(page.getByTestId('mcp-tool-summary')).toHaveCount(0);
+  await expect(page.getByTestId('session-feedback')).toContainText(/Found 1 MCP tools/i);
 
   await page.evaluate(() => {
     const adapter = (window as unknown as {

--- a/tests/e2e/ui-overhaul.spec.ts
+++ b/tests/e2e/ui-overhaul.spec.ts
@@ -12,7 +12,9 @@ test.describe("UI Overhaul critical path", () => {
 
     await entryButton.click();
 
-    await expect(page.getByText(/status: connected/i)).toBeVisible();
+    await expect(page.getByTestId("session-feedback")).toContainText(
+      /connected to session/i,
+    );
     await expect(
       page.getByTestId("voice-activity-indicator"),
     ).toHaveAttribute("aria-label", /ai is speaking/i, { timeout: 7_500 });


### PR DESCRIPTION
## Summary
- replace the MCP tool banner with a snackbar so the layout stays clean
- suppress catalog toasts while a session is connected to preserve connection feedback
- align e2e specs with the new snackbar signalling

## Testing
- npx playwright test tests/e2e/mcp-tools.spec.ts tests/e2e/ui-overhaul.spec.ts

Closes #56