### PR TITLE
SDD: mcp-resources-tracking T005

### DIFF
--- a/sdd/features/mcp-resources-tracking/spec.md
+++ b/sdd/features/mcp-resources-tracking/spec.md
@@ -72,3 +72,13 @@ What external factors does this feature depend on?
 ### Assumptions
 - Resource contents are predominantly UTF-8 text; binary payloads can be summarized without degrading the agent experience
 - Realtime sessions already handle injected system messages without extra UX changes
+
+## Implementation Notes
+
+- Tasks T001–T004 ship the config flag, tracker, SSE endpoint, and realtime adapter wiring. Task
+  T005 closes the loop with documentation updates (README + AGENTS) and the Playwright spec
+  `tests/e2e/mcp-resource-tracking.spec.ts` that simulates a tracker event over
+  `/api/mcp/resource-events` and asserts the transcript message is delivered once a session is
+  connected.
+- Keep `sdd/features/mcp-resources-tracking/tasks.md` in sync with delivery status; Task T005 is now
+  marked `Completed` so regressions should update the tracker accordingly.

--- a/sdd/features/mcp-resources-tracking/tasks.md
+++ b/sdd/features/mcp-resources-tracking/tasks.md
@@ -94,15 +94,16 @@ Wire the `McpAdapter` to the SSE feed, surface lightweight resource notification
 ---
 
 ## Task T005: Documentation & end-to-end validation
-**Status:** Pending
+**Status:** Completed
 **Dependencies:** T001–T004
 **Files:**
 - `README.md`, `AGENTS.md`
 - `sdd/features/mcp-resources-tracking/spec.md`
-- `tests/e2e/mcp-resource-tracking.spec.ts` (new)
+- `tests/e2e/mcp-resource-tracking.spec.ts`
 
 ### Description
-Update project docs and SDD materials with tracker details plus add an end-to-end Playwright (or Jest integration) scenario exercising the full flow from config flag to realtime message delivery.
+Update project docs and SDD materials with tracker details plus add an end-to-end Playwright (or
+Jest integration) scenario exercising the full flow from config flag to realtime message delivery.
 
 ### Acceptance Criteria
 - Docs explain setup steps, telemetry expectations, and troubleshooting

--- a/tests/e2e/mcp-resource-tracking.spec.ts
+++ b/tests/e2e/mcp-resource-tracking.spec.ts
@@ -1,0 +1,45 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/session";
+
+const RESOURCE_EVENTS_ROUTE = "**/api/mcp/resource-events";
+
+test.describe("MCP resource tracking", () => {
+  test("streams tracker updates into the transcript", async ({ page }) => {
+    test.setTimeout(45_000);
+
+    await page.route(RESOURCE_EVENTS_ROUTE, async (route) => {
+      const timestamp = Date.now();
+      const body = [
+        "retry: 5000\n\n",
+        `data: {"type":"handshake","status":"ready","timestamp":${timestamp}}\n\n`,
+        `data: {"type":"resource_update","serverId":"codex-tasks","resourceUri":"task://demo-resource","timestamp":${timestamp + 1000}}\n\n`,
+      ].join("");
+
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          Connection: "keep-alive",
+        },
+        body,
+      });
+
+      await page.unroute(RESOURCE_EVENTS_ROUTE);
+    });
+
+    await page.goto("/");
+
+    const entryButton = page.getByRole("button", { name: /start voice session/i });
+    await entryButton.click();
+
+    await expect(page.getByTestId("session-feedback")).toContainText(
+      /connected to session/i,
+    );
+
+    await page.getByTestId("transcript-toggle").click();
+
+    await expect(page.getByTestId("transcript-entries")).toContainText(
+      /Resource task:\/\/demo-resource updated for MCP server codex-tasks/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- document the trackResources flag, SSE feed, and troubleshooting in README + AGENTS while noting task status in the spec
- add tests/e2e/mcp-resource-tracking.spec.ts to stream a mocked tracker event and ensure the transcript receives the update
- teach MockRealtimeSession to honor conversation.item.create payloads so injected messages reach the transcript store

## Testing
- npm test
- npm run test:e2e -- mcp-resource-tracking.spec.ts

Closes #70