### PR TITLE
SDD: main-view-visualisation-markdown T004

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Set `NEXT_PUBLIC_ENABLE_TELEMETRY=1` (and optionally `MCP_ENABLE_TELEMETRY=1`) t
 - Playwright specs reside in `tests/e2e/`; `tests/e2e/mcp-tools.spec.ts` exercises catalog hydration and a mocked invocation end-to-end.
 - `tests/e2e/mcp-resource-tracking.spec.ts` keeps the SSE bridge honest by simulating a tracker
   event and asserting the transcript message delivery once a realtime session connects.
+- `tests/e2e/main-view-markdown.spec.ts` drives the `show_markdown` tool, validates tables + math,
+  and asserts telemetry render/engagement events fire exactly once under Fast 3G conditions.
 - Run `npm run test:e2e` from a second terminal while the dev server is running.
 
 ## Security Notes

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     env: {
       NEXT_PUBLIC_USE_REALTIMEMOCK: "1",
+      NEXT_PUBLIC_ENABLE_TELEMETRY: "1",
     },
     stdout: "pipe",
     stderr: "pipe",

--- a/sdd/features/main-view-visualisation-markdown/tasks.md
+++ b/sdd/features/main-view-visualisation-markdown/tasks.md
@@ -78,7 +78,7 @@ plus metrics expectations for the Markdown viewer.
 ---
 
 ## Task T004: E2E Markdown Flow
-**Status:** Pending
+**Status:** Completed
 **Dependencies:** T003
 **Files:**
 - `tests/e2e/main-view-markdown.spec.ts`

--- a/tests/e2e/main-view-markdown.spec.ts
+++ b/tests/e2e/main-view-markdown.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from "@playwright/test";
+import { test, throttleToFast3G } from "./fixtures/session";
+
+const MARKDOWN_PAYLOAD = `# Quarterly Memo\n\n- Revenue up **24%**\n- Expansion continues\n\n| Region | Q1 | Q2 |\n| ------ | --- | --- |\n| NA | 12.4 | 13.1 |\n| LATAM | 3.1 | 4.8 |\n\nInline math $a^2 + b^2 = c^2$ and block math:$$\\frac{a}{b} = \\sum_{n=1}^{\\infty} x_n$$`;
+
+test.describe("Markdown viewer", () => {
+  test("shows show_markdown output and logs telemetry", async ({ page }) => {
+    test.setTimeout(60_000);
+    const restoreNetwork = await throttleToFast3G(page);
+
+    await page.addInitScript(() => {
+      const globalWindow = window as typeof window & {
+        __vibeTelemetryEvents?: Array<{ event: string; payload: unknown }>;
+      };
+      globalWindow.__vibeTelemetryEvents = [];
+      window.addEventListener("vibechat:telemetry", (event) => {
+        const detail = (event as CustomEvent<{ event: string; payload: unknown }>).detail;
+        globalWindow.__vibeTelemetryEvents?.push(detail);
+      });
+    });
+
+    try {
+      await page.goto("/");
+
+      const entryButton = page.getByRole("button", { name: /start voice session/i });
+      await expect(entryButton).toBeVisible();
+      await entryButton.click();
+
+      await expect(page.getByTestId("session-feedback")).toContainText(
+        /connected to session/i,
+      );
+
+      await page.waitForFunction(() => Boolean((window as typeof window & {
+          __vibeMarkdownStore?: { apply(input: unknown): unknown };
+        }).__vibeMarkdownStore));
+
+      await page.evaluate((markdown) => {
+        const scopedWindow = window as typeof window & {
+          __vibeMarkdownStore?: { apply(input: unknown): unknown };
+        };
+        scopedWindow.__vibeMarkdownStore?.apply({
+          title: "Quarterly Memo",
+          markdown,
+        });
+      }, MARKDOWN_PAYLOAD);
+
+      const viewer = page.getByTestId("markdown-viewer");
+      await expect(viewer).toBeVisible();
+      await expect(viewer).toContainText(/quarterly memo/i);
+      await expect(viewer).toContainText(/Revenue up/i);
+      await expect(viewer).toHaveAttribute("tabindex", "0");
+      await expect(page.getByRole("table")).toBeVisible();
+      await expect(page.locator(".katex").first()).toBeVisible();
+
+      await page.waitForTimeout(5_500);
+
+      const telemetry = await page.evaluate(() => {
+        const scopedWindow = window as typeof window & {
+          __vibeTelemetryEvents?: Array<{ event: string; payload: Record<string, unknown> }>;
+        };
+        return scopedWindow.__vibeTelemetryEvents ?? [];
+      });
+
+      const renderEvents = telemetry.filter((entry) => entry.event === "session_markdown_rendered");
+      const engagementEvents = telemetry.filter(
+        (entry) => entry.event === "session_markdown_engagement",
+      );
+
+      expect(renderEvents).toHaveLength(1);
+      expect(renderEvents[0]?.payload.title).toBe("Quarterly Memo");
+      expect(renderEvents[0]?.payload.bytes).toBeGreaterThan(0);
+
+      expect(engagementEvents).toHaveLength(1);
+      expect(engagementEvents[0]?.payload.documentId).toBe(
+        renderEvents[0]?.payload.documentId,
+      );
+      expect(Number(engagementEvents[0]?.payload.durationMs)).toBeGreaterThanOrEqual(5_000);
+    } finally {
+      await restoreNetwork();
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- add tests/e2e/main-view-markdown.spec.ts to simulate the show_markdown tool, verify tables + math rendering, and assert telemetry render/engagement events fire exactly once under Fast 3G\n- expose telemetry events to the browser by setting NEXT_PUBLIC_ENABLE_TELEMETRY=1 in the Playwright web server env and document the spec in README\n- mark SDD task T004 complete\n\n## Testing\n- npm run test:e2e -- main-view-markdown.spec.ts\n\nCloses #61